### PR TITLE
Store resolved github author in a cache

### DIFF
--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -20,17 +20,21 @@ git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-duty-
 git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-admin.git
 git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-search-query-parser.git
 
+if [ -f ".github_authors_cache" ]; then
+  rm .github_authors_cache
+  touch .github_authors_cache
+else
+  touch .github_authors_cache
+fi
+
+cache_file="$PWD/.github_authors_cache"
+
 cachedFetchAuthor() {
   local email="$1"
-  local cache_file="../.github_authors_cache"
 
-  if [ ! -f "$cache_file" ]; then
-    touch "$cache_file"
-  fi
-
-  result=$(grep "^$email|" "$cache_file")
+  result=$(grep "^$email," "$cache_file")
   if [ "$result" != "" ]; then
-    author=$(echo "$result" | cut -d "|" -f 2)
+    author=$(echo "$result" | awk -F, '{print $2}')
   else
     author=$(curl -s "https://api.github.com/search/users?q=$email+in:email" | jq -r '.items[0].login')
 
@@ -40,7 +44,7 @@ cachedFetchAuthor() {
       author="<https://github.com/$author|$author>"
     fi
 
-    echo "$email|$author" >> "$cache_file"
+    echo "$email,$author" >> "$cache_file"
   fi
 
   # Return the author

--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -20,6 +20,33 @@ git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-duty-
 git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-admin.git
 git clone --quiet --depth 100 https://github.com/trade-tariff/trade-tariff-search-query-parser.git
 
+cachedFetchAuthor() {
+  local email="$1"
+  local cache_file="../.github_authors_cache"
+
+  if [ ! -f "$cache_file" ]; then
+    touch "$cache_file"
+  fi
+
+  result=$(grep "^$email|" "$cache_file")
+  if [ "$result" != "" ]; then
+    author=$(echo "$result" | cut -d "|" -f 2)
+  else
+    author=$(curl -s "https://api.github.com/search/users?q=$email+in:email" | jq -r '.items[0].login')
+
+    if [ "$author" == "null" ]; then
+      author="$email"
+    else
+      author="<https://github.com/$author|$author>"
+    fi
+
+    echo "$email|$author" >> "$cache_file"
+  fi
+
+  # Return the author
+  echo "$author"
+}
+
 # Log function to print the logs for a repository
 log_for() {
   local url=$1
@@ -48,22 +75,11 @@ log_for() {
     while read -r line; do
       message=$(echo "$line" | awk -F\| '{print $1}')
       subject_line=$(echo "$line" | awk -F\| '{print $2}')
-      # Extract the pull request number from the commit message
+      email=$(echo "$line" | awk -F\| '{print $3}')
+      username=$(cachedFetchAuthor "$email")
       pr_number=$(echo "$subject_line" | sed 's/^Merge pull request #\([0-9]*\).*$/\1/g')
-      # Construct the link to the pull request
       pr_link="https://github.com/trade-tariff/${repo}/pull/${pr_number}"
-      # Extract the author's name from the Git log
-      author=$(echo "$line" | awk -F\| '{print $3}')
-      # Use the GitHub REST API to retrieve the author's profile information, including their GitHub username
-      username=$(curl --silent "https://api.github.com/search/users?q=$author+in:email" | jq -r '.items[0].login')
 
-      # if the username is null then default to the author's name
-      if [ "$username" == "null" ]; then
-        username=$author
-      else
-        # otherwise generate a link to the author's GitHub profile
-        username="<https://github.com/$username|$username>"
-      fi
 
       # Replace the commit message with a markdown link to the pull request, including the author's GitHub username
       echo "* <${pr_link}|${message}> by ${username}"


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

This change produces a cache file containing the following:

```
william.michael.fish@gmail.com|<https://github.com/willfish|willfish>
maverickvi@users.noreply.github.com|maverickvi@users.noreply.github.com
jeb@jdwilkins.co.uk|jeb@jdwilkins.co.uk
```

I have added/removed/altered:

- [x] Added cached fetch of resolved github usernames to release note script

### Why?

I am doing this because:

- This solves issues where we're being rate limited by the github api and spamming to fetch usernames for lots of merge commits
