### PR TITLE
Move to 5 days for release note history

### DIFF
--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -196,12 +196,12 @@ all_logs() {
   log_for "https://www.trade-tariff.service.gov.uk/duty-calculator/healthcheck" "trade-tariff-duty-calculator"
   log_for "https://tariff-admin-production.london.cloudapps.digital/healthcheck" "trade-tariff-admin"
   log_for "https://www.trade-tariff.service.gov.uk/api/search/healthcheck" "trade-tariff-search-query-parser"
-  last_n_logs_for "trade-tariff-api-docs" 3
-  last_n_logs_for "trade-tariff-testing" 3
-  last_n_logs_for "process-appendix-5a" 3
-  last_n_logs_for "download-CDS-files" 3
-  last_n_logs_for "trade-tariff-platform-terragrunt" 3
-  last_n_logs_for "trade-tariff-platform-terraform-modules" 3
+  last_n_logs_for "trade-tariff-api-docs" 5
+  last_n_logs_for "trade-tariff-testing" 5
+  last_n_logs_for "process-appendix-5a" 5
+  last_n_logs_for "download-CDS-files" 5
+  last_n_logs_for "trade-tariff-platform-terragrunt" 5
+  last_n_logs_for "trade-tariff-platform-terraform-modules" 5
 }
 
 all_logs


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Move to 5 days for release notes history

### Why?

I am doing this because:

- Between Thursday and Monday we'll lose visiblity on what got released for these repos
