### PR TITLE
Escape release-note json payload to slack

### DIFF
--- a/bin/post_release_notes.sh
+++ b/bin/post_release_notes.sh
@@ -7,9 +7,10 @@ webhook_url="$SLACK_WEBHOOK"
 channel="#$SLACK_CHANNEL"
 username="$SLACK_USERNAME"
 message=$(bash bin/generate_release_notes.sh)
+escaped_message=$(echo "$message" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | awk '{printf "%s\\n", $0}')
 payload="{
   \"channel\": \"$channel\",
-  \"text\": \"$message\",
+  \"text\": \"$escaped_message\",
   \"username\": \"$username\",
   \"mrkdwn\": true
 }"


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added escaping of the json payload to slack

### Why?

I am doing this because:

- This wasn't required previously but we're receiving invalid_payload messages in the github action output
