### PR TITLE
HOTT-4932 Added ecsexec.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,31 @@ For example, this will produce:
 | <a href="https://www.trade-tariff.service.gov.uk/commodities/1518009122" target="_blank">1518009122</a> | Consigned from the United Kingdom |
 | <a href="https://www.trade-tariff.service.gov.uk/commodities/1518009123" target="_blank">1518009123</a> | Consigned from China |
 | <a href="https://www.trade-tariff.service.gov.uk/commodities/1518009131" target="_blank">1518009131</a> | Consigned from the United Kingdom |
+
+### bin/ecsexec.sh
+
+Script to get an ECS Exec shell up on the AWS environment you are currently in. By default it will start a `rails console`
+
+Its intended copied to the AWS Console where there are limited shell tools but will probably work fine locally with AWS Session Manager
+
+```shell
+ecsexec.sh <service> [<command>]
+```
+
+eg, to get a rails console for the XI service
+
+```shell
+ecsexec.sh xi
+```
+
+eg, to start a bash shell for the UK service
+
+```shell
+ecsexec.sh uk sh
+```
+
+eg, to run a rake task for XI
+
+```shell
+ecsexec.sh xi "bundle exec rake tariff:jobs"
+```

--- a/bin/ecsexec.sh
+++ b/bin/ecsexec.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+command=$2
+if [ "${command}x" == "x" ]; then
+  command="bin/rails c"
+fi
+
+cluster=$(aws ecs list-clusters | jq -r '.clusterArns[]')
+service=$(aws ecs list-services --cluster "${cluster}" | jq -r '.serviceArns[]' | grep "worker-${1}")
+task=$(aws ecs list-tasks --cluster "${cluster}" --service-name "${service}" | jq -r '.taskArns[]')
+
+
+echo "using: $(echo $cluster | cut -d '/' -f 2 | cut -d '-' -f 4 | tr a-z A-Z)"
+sleep 4
+aws ecs execute-command --cluster $cluster --task $task --container "worker-${1}" --interactive --command "/bin/sh -c \"RAILS_LOG_LEVEL=debug ${command}\""


### PR DESCRIPTION
Makes it easier to start a ecs shell from the AWS Web Console

### Jira link

HOTT-4932

### What?

I have added/removed/altered:

- [x] Added an `ecsexec.sh` script

### Why?

I am doing this because:

- It makes it easier to get a rails console or bash prompt into the ecs worker instances

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages
