### PR TITLE
BAU: Adds tech-docs to release notes

### DIFF
--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -21,5 +21,5 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "ott-core"
           SLACK_USERNAME: "Release Bot"
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXCLUDED_DEPLOYERS: ${{ vars.EXCLUDED_DEPLOYERS }}

--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -36,6 +36,7 @@ repos=(
   "https://github.com/trade-tariff/trade-tariff-platform-aws-terraform.git"
   "https://github.com/trade-tariff/trade-tariff-platform-terraform-modules.git"
   "https://github.com/trade-tariff/trade-tariff-reporting.git"
+  "https://github.com/trade-tariff/trade-tariff-tech-docs.git"
 )
 
 for repo in "${repos[@]}"; do
@@ -206,6 +207,7 @@ all_logs() {
   last_n_logs_for "trade-tariff-platform-aws-terraform" 5
   last_n_logs_for "trade-tariff-platform-terraform-modules" 5
   last_n_logs_for "trade-tariff-reporting" 5
+  last_n_logs_for "trade-tariff-tech-docs" 5
 }
 
 all_logs


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- Adds tech-docs to release notes
- Uses GITHUB_TOKEN provided by Github Actions

### Why?

I am doing this because:

- Provide more visibility around tech docs
