### PR TITLE
BAU: Provide visibility over the tech-docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Jira link
 
-HOTT-<TODO>
+OTT-<TODO>
 
 ### What?
 

--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -36,6 +36,7 @@ repos=(
   "https://github.com/trade-tariff/trade-tariff-platform-aws-terraform.git"
   "https://github.com/trade-tariff/trade-tariff-platform-terraform-modules.git"
   "https://github.com/trade-tariff/trade-tariff-reporting.git"
+  "https://github.com/trade-tariff/trade-tariff-tech-docs.git"
 )
 
 for repo in "${repos[@]}"; do
@@ -206,6 +207,7 @@ all_logs() {
   last_n_logs_for "trade-tariff-platform-aws-terraform" 5
   last_n_logs_for "trade-tariff-platform-terraform-modules" 5
   last_n_logs_for "trade-tariff-reporting" 5
+  last_n_logs_for "trade-tariff-tech-docs" 5
 }
 
 all_logs


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- Adds visibility for the tech docs repo
- Fix dead reference to an older jira board

### Why?

I am doing this because:

- For visibility
