### PR TITLE
BAU: Fixes admin release type

### DIFF
--- a/bin/generate_release_notes.sh
+++ b/bin/generate_release_notes.sh
@@ -218,7 +218,7 @@ all_logs() {
   log_for "https://www.trade-tariff.service.gov.uk/healthcheck" "trade-tariff-frontend" "manual"
   log_for "https://www.trade-tariff.service.gov.uk/api/v2/healthcheck" "trade-tariff-backend" "manual"
   log_for "https://www.trade-tariff.service.gov.uk/duty-calculator/healthcheck" "trade-tariff-duty-calculator" "manual"
-  log_for "https://admin.trade-tariff.service.gov.uk/healthcheck" "trade-tariff-admin" "n/a"
+  log_for "https://admin.trade-tariff.service.gov.uk/healthcheck" "trade-tariff-admin" "manual"
   last_n_logs_for "trade-tariff-api-docs" "continuous"
   last_n_logs_for "trade-tariff-testing" "n/a"
   last_n_logs_for "process-appendix-5a" "continuous"


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Fixes admin release type

### Why?

I am doing this because:

- I had this confused with signon which only deploys to development and staging environments
