### PR TITLE
HMRC-765: Adds an e2e-tests workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,39 @@
+name: e2e-tests
+on:
+  workflow_call:
+    inputs:
+      test-url:
+        description: 'The URL to run the E2E tests against'
+        required: true
+        type: string
+  workflow_dispatch:
+      inputs:
+        test-url:
+          description: 'The URL to run the E2E tests against'
+          required: true
+          type: string
+
+jobs:
+  test:
+    environment: development
+    timeout-minutes: 60
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: trade-tariff-e2e-tests
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: lts/*
+    - name: Install dependencies
+      run: npm install -g yarn && yarn
+    - name: Check code
+      run: yarn run lint
+    - name: Install Playwright Browsers
+      run: yarn playwright install --with-deps chromium
+    - name: Run Playwright tests
+      run: yarn run test
+      env:
+        BASE_URL: {{ github.event.inputs.test-url }}
+        CI: true


### PR DESCRIPTION
### Jira link

[HMRC-765](https://transformuk.atlassian.net/browse/HMRC-765)

### What?

I have added/removed/altered:

- [x] Added a shared workflow to run the e2e tests with any test url

### Why?

I am doing this because:

- This is something we want to run across circleci and github action workflows
