### PR TITLE
Correct fetch secret script

### DIFF
--- a/.github/actions/fetch-secrets/action.yml
+++ b/.github/actions/fetch-secrets/action.yml
@@ -25,5 +25,5 @@ runs:
           --secret-id "${{ inputs.secret-name }}" \
           --query "SecretString" \
           --output text \
-          | jq -r 'to_entries | map("(.key)=(.value)") | join("\n")' > ${{ inputs.env-file }}
+          | jq -r 'to_entries | map("\(.key)=\(.value)") | join("\n")' > ${{ inputs.env-file }}
       shell: bash


### PR DESCRIPTION
### Jira link


### What?

I have added/removed/altered:

- Altered jq expression to escape parentheses for correct key-value formatting


### Why?

I am doing this because:

- The unquoted parentheses in the jq expression were being misinterpreted by the shell, leading to errors.

- By adding the escape characters, the jq expression now formats key-value pairs correctly when writing them to the .env file.


### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
