### PR TITLE
BAU: Leave only manually deployed stuff in release notes

### DIFF
--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -19,12 +19,8 @@ mkdir repos
 cd repos || exit 1
 
 repos=(
-  "https://github.com/trade-tariff/trade-tariff-frontend.git"
   "https://github.com/trade-tariff/trade-tariff-backend.git"
-  "https://github.com/trade-tariff/trade-tariff-api-docs.git"
   "https://github.com/trade-tariff/trade-tariff-platform-aws-terraform.git"
-  "https://github.com/trade-tariff/trade-tariff-platform-terraform-modules.git"
-  "https://github.com/trade-tariff/trade-tariff-lambdas-fpo-search.git"
 )
 
 for repo in "${repos[@]}"; do
@@ -136,12 +132,8 @@ last_n_logs_for() {
 }
 
 all_logs() {
-  log_for "https://www.trade-tariff.service.gov.uk/healthcheck" "trade-tariff-frontend" "manual"
   log_for "https://www.trade-tariff.service.gov.uk/api/v2/healthcheck" "trade-tariff-backend" "manual"
-  last_n_logs_for "trade-tariff-api-docs" "continuous"
   last_n_logs_for "trade-tariff-platform-aws-terraform" "manual"
-  last_n_logs_for "trade-tariff-platform-terraform-modules" "n/a"
-  last_n_logs_for "trade-tariff-lambdas-fpo-search" "continuous"
 }
 
 all_logs


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Remove non-manually deployed things from release notes

### Why?

I am doing this because:

- We've migrated to CD in the frontend now so there are very few apps (just the backend and terraform) that rollout manually
