### PR TITLE
BAU: Allow for up to 2 deployments to happen in order

### DIFF
--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -44,7 +44,7 @@ runs:
         ssh-key: ${{ inputs.ssh-key }}
     - run: cd terraform && terraform init -backend-config=backends/${{ inputs.environment }}.tfbackend
       shell: bash
-    - run: cd terraform && terraform apply -var-file=config_${{ inputs.environment }}.tfvars -auto-approve
+    - run: cd terraform && terraform apply -var-file=config_${{ inputs.environment }}.tfvars -auto-approve -lock-timeout=10m
       shell: bash
       env:
         TF_VAR_docker_tag: ${{ steps.resolved-ref.outputs.RESOLVED_REF }}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added lock-timeout of 10 minutes (hand wavily around 2 deploys)

### Why?

I am doing this because:

- This should prevent us from instantly failing due to an inability to acquire the lock with successive merges
