### PR TITLE
HMRC-896: Adds workflow for e2e-fpo-tests

### DIFF
--- a/.github/workflows/e2e-fpo-tests.yml
+++ b/.github/workflows/e2e-fpo-tests.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          repository: trade-tariff/trade-tariff-e2e-tests
+          repository: trade-tariff/trade-tariff-fpo-dev-hub-e2e
           ref: ${{ env.REF }}
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/e2e-fpo-tests.yml
+++ b/.github/workflows/e2e-fpo-tests.yml
@@ -1,4 +1,5 @@
-name: e2e-tests
+
+name: e2e-fpo-tests
 
 on:
   workflow_call:
@@ -7,22 +8,16 @@ on:
         description: 'The URL to run the E2E tests against'
         required: true
         type: string
-      admin-test-url:
-        description: 'The admin URL to run the E2E tests against'
-        required: false
-        type: string
-        default: 'https://admin.dev.trade-tariff.service.gov.uk'
       ref:
         description: 'The e2e-test repo reference to run with'
         type: string
         default: 'main'
-      basic-password:
-        description: 'The basic auth password'
-        required: false
-        type: string
     secrets:
-      basic_password:
-        description: 'The basic auth password'
+      scp-username:
+        description: 'The scp auth username'
+        required: false
+      scp-password:
+        description: 'The scp auth password'
         required: false
   workflow_dispatch:
     inputs:
@@ -30,17 +25,16 @@ on:
         description: 'The URL to run the E2E tests against'
         required: true
         type: string
-      admin-test-url:
-        description: 'The admin URL to run the E2E tests against'
-        required: false
-        type: string
-        default: 'https://admin.dev.trade-tariff.service.gov.uk'
       ref:
         description: 'The e2e-test repo reference to run with'
         type: string
         default: 'main'
-      basic-password:
-        description: 'The basic auth password'
+      scp-username:
+        description: 'The scp auth username'
+        required: false
+        type: string
+      scp-password:
+        description: 'The scp auth password'
         required: false
         type: string
 
@@ -54,14 +48,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             {
-              echo "ADMIN_URL=${{ github.event.inputs.admin-test-url }}"
-              echo "BASE_URL=${{ github.event.inputs.test-url }}"
+              echo "URL=${{ github.event.inputs.test-url }}"
               echo "REF=${{ github.event.inputs.ref }}"
             } >> "$GITHUB_ENV"
           else
             {
-              echo "ADMIN_URL=${{ inputs.admin-test-url }}"
-              echo "BASE_URL=${{ inputs.test-url }}"
+              echo "URL=${{ inputs.test-url }}"
               echo "REF=${{ inputs.ref }}"
             } >> "$GITHUB_ENV"
           fi
@@ -88,7 +80,7 @@ jobs:
 
       - run: yarn run test
         env:
-          ADMIN_URL: ${{ env.ADMIN_URL }}
-          BASE_URL: ${{ env.BASE_URL }}
-          BASIC_PASSWORD: ${{ secrets.BASIC_PASSWORD }}
+          URL: ${{ env.URL }}
+          SCP_USERNAME: ${{ secrets.scp-username }}
+          SCP_PASSWORD: ${{ secrets.scp-password }}
           CI: true

--- a/.github/workflows/e2e-fpo-tests.yml
+++ b/.github/workflows/e2e-fpo-tests.yml
@@ -4,10 +4,10 @@ name: e2e-fpo-tests
 on:
   workflow_call:
     inputs:
-      test-url:
-        description: 'The URL to run the E2E tests against'
-        required: true
+      test-environment:
+        description: 'The e2e-test environment to run against'
         type: string
+        default: 'development'
       ref:
         description: 'The e2e-test repo reference to run with'
         type: string
@@ -21,10 +21,10 @@ on:
         required: false
   workflow_dispatch:
     inputs:
-      test-url:
-        description: 'The URL to run the E2E tests against'
-        required: true
+      test-environment:
+        description: 'The e2e-test environment to run against'
         type: string
+        default: 'development'
       ref:
         description: 'The e2e-test repo reference to run with'
         type: string
@@ -48,12 +48,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             {
-              echo "URL=${{ github.event.inputs.test-url }}"
+              echo "PLAYWRIGHT_ENV=${{ github.event.inputs.test-environment }}"
               echo "REF=${{ github.event.inputs.ref }}"
             } >> "$GITHUB_ENV"
           else
             {
-              echo "URL=${{ inputs.test-url }}"
+              echo "PLAYWRIGHT_ENV=${{ inputs.test-environment }}"
               echo "REF=${{ inputs.ref }}"
             } >> "$GITHUB_ENV"
           fi
@@ -80,7 +80,7 @@ jobs:
 
       - run: yarn run test
         env:
-          URL: ${{ env.URL }}
+          PLAYWRIGHT_ENV: ${{ env.PLAYWRIGHT_ENV }}
           SCP_USERNAME: ${{ secrets.scp-username }}
           SCP_PASSWORD: ${{ secrets.scp-password }}
           CI: true

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
 jobs:
   test:
     environment: development


### PR DESCRIPTION
This is going to be called by the fpo/dev-hub repositories

### Jira link

[HMRC-896](https://transformuk.atlassian.net/browse/HMRC-896)

### What?

I have added/removed/altered:

- [x] Added workflow for the e2e tests that drive fpo functionality

### Why?

I am doing this because:

- This is needed to migrate the fpo lambda repo to github actions
