### PR TITLE
BAU: Removes all but last of release note repos

### DIFF
--- a/bin/generate-release-notes
+++ b/bin/generate-release-notes
@@ -19,7 +19,6 @@ mkdir repos
 cd repos || exit 1
 
 repos=(
-  "https://github.com/trade-tariff/trade-tariff-backend.git"
   "https://github.com/trade-tariff/trade-tariff-platform-aws-terraform.git"
 )
 
@@ -132,7 +131,6 @@ last_n_logs_for() {
 }
 
 all_logs() {
-  log_for "https://www.trade-tariff.service.gov.uk/api/v2/healthcheck" "trade-tariff-backend" "manual"
   last_n_logs_for "trade-tariff-platform-aws-terraform" "manual"
 }
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removes all but the last release note repos

### Why?

I am doing this because:

- We've moved to Continuous Deployments of the backend repo
