### PR TITLE
HMRC-962: Notify in production-alerts

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -18,7 +18,7 @@ runs:
   steps:
     - uses: rtCamp/action-slack-notify@v2
       env:
-        SLACK_CHANNEL: "deployments"
+        SLACK_CHANNEL: ${{ inputs.slack_channel }}
         SLACK_USERNAME: "Deploy Bot"
         SLACK_WEBHOOK: ${{ inputs.slack_webhook }}
         SLACK_ICON_EMOJI: ":robot_face:"


### PR DESCRIPTION
### Jira link

[HMRC-962](https://transformuk.atlassian.net/browse/HMRC-962)

### What?

I have added/removed/altered:

- [ ] Added slack channel as input param

### Why?

I am doing this because:

- We should be able to notify different channels depends on the environment