### PR TITLE
HMRC-903: Adds terraform docs action

### DIFF
--- a/.github/actions/setup-terraform-docs/action.yml
+++ b/.github/actions/setup-terraform-docs/action.yml
@@ -1,0 +1,13 @@
+name: 'Setup terraform docs'
+description: 'Setup terraform docs'
+
+inputs:
+  terraform_docs_version:
+    required: false
+    default: '0.20.0'
+
+runs:
+  using: 'composite'
+  steps:
+    - run: GOBIN=/usr/local/bin/ go install github.com/terraform-docs/terraform-docs@v${{ inputs.terraform_docs_version }}
+      shell: bash


### PR DESCRIPTION
### Jira link

[HMRC-903](https://transformuk.atlassian.net/browse/HMRC-903)

### What?

I have added/removed/altered:

- [x] Added terraform docs action

### Why?

I am doing this because:

- This is needed for easy installation of terraform docs
