### PR TITLE
BAU: Support build args in build and push action

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -9,6 +9,9 @@ inputs:
   region:
     required: false
     default: 'eu-west-2'
+  build-args:
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -51,6 +54,10 @@ runs:
         fi
 
         echo "$REF" > REVISION
-        docker build -t "$IMAGE_NAME" .
+        build_args=""
+        for arg in ${{ inputs.build-args }}; do
+          build_args="$build_args --build-arg $arg"
+        done
+        docker build -t "$IMAGE_NAME" . $build_args
         docker push "$IMAGE_NAME"
       shell: bash


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added support for build args in build and push action

### Why?

I am doing this because:

- This is required so we can simplify upgrades of our language and framework dependencies that are supported by the docker image in a dynamic way
