### PR TITLE
Lock Docker Compose to v2.36.0 to prevent preevy from failing

### DIFF
--- a/.github/actions/lock-docker-compose/action.yml
+++ b/.github/actions/lock-docker-compose/action.yml
@@ -1,0 +1,17 @@
+name: Lock Docker Compose Version
+description: Download and install a specific version of Docker Compose (v2.36.0)
+
+inputs:
+  version:
+    description: "Docker Compose version"
+    required: false
+    default: "v2.36.0"
+
+runs:
+  using: composite
+  steps: 
+    - run: |
+        mkdir -p ~/.docker/cli-plugins/
+        curl -sSL https://github.com/docker/compose/releases/download/${{ inputs.version }}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+        chmod +x ~/.docker/cli-plugins/docker-compose
+      shell: bash


### PR DESCRIPTION
### Jira link

HMRC

### What?

I have added/removed/altered:

- [x] Added a GitHub Action to lock Docker Compose to v2.36.0 as a temporary workaround until Preevy's source code is updated.

### Why?

I am doing this because:

- Preevy currently fails with newer versions of Docker Compose due to the deprecation of the docker-compose subcommand.
- This patch ensures stability until Preevy’s codebase is updated to support newer Docker Compose versions.