### PR TITLE
HMRC-1306: Remove support for assuming role via env var

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -9,29 +9,18 @@ inputs:
   region:
     required: false
     default: 'eu-west-2'
-  build-args:
-    required: false
-    default: ''
   role-to-assume:
     description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
+  build-args:
     required: false
     default: ''
 runs:
   using: 'composite'
   steps:
-    - id: role-to-assume
-      run: |
-        if [ -z "${{ inputs.role-to-assume }}" ]; then
-          echo "::warning::Falling back to IAM_ROLE_ARN environment variable. Please update to use role-to-assume input."
-          echo "role_to_assume=$IAM_ROLE_ARN" >> "$GITHUB_OUTPUT"
-        else
-          echo "::notice::Using explicit role-to-assume input: ${{ inputs.role-to-assume }}"
-          echo "role_to_assume=${{ inputs.role-to-assume }}" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.role-to-assume.outputs.role_to_assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
     - id: resolved-ref
       run: |

--- a/.github/actions/fetch-secrets/action.yml
+++ b/.github/actions/fetch-secrets/action.yml
@@ -9,30 +9,19 @@ inputs:
     description: 'Path to the environment file'
     required: false
     default: '.env'
+  role-to-assume:
+    description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
   region:
     required: false
     default: 'eu-west-2'
-  role-to-assume:
-    description: 'The IAM role ARN to assume for AWS operations.'
-    required: false
-    default: ''
 
 runs:
   using: "composite"
   steps:
-    - id: role-to-assume
-      run: |
-        if [ -z "${{ inputs.role-to-assume }}" ]; then
-          echo "::warning::Falling back to IAM_ROLE_ARN environment variable. Please update to use role-to-assume input."
-          echo "role_to_assume=$IAM_ROLE_ARN" >> "$GITHUB_OUTPUT"
-        else
-          echo "::notice::Using explicit role-to-assume input: ${{ inputs.role-to-assume }}"
-          echo "role_to_assume=${{ inputs.role-to-assume }}" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.role-to-assume.outputs.role_to_assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
 
     - name: Fetch and store secrets

--- a/.github/actions/tag-production/action.yml
+++ b/.github/actions/tag-production/action.yml
@@ -6,29 +6,18 @@ inputs:
     required: true
   ref:
     required: true
+  role-to-assume:
+    description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
   region:
     required: false
     default: 'eu-west-2'
-  role-to-assume:
-    description: 'The IAM role ARN to assume for AWS operations.'
-    required: false
-    default: ''
 runs:
   using: 'composite'
   steps:
-    - id: role-to-assume
-      run: |
-        if [ -z "${{ inputs.role-to-assume }}" ]; then
-          echo "::warning::Falling back to IAM_ROLE_ARN environment variable. Please update to use role-to-assume input."
-          echo "role_to_assume=$IAM_ROLE_ARN" >> "$GITHUB_OUTPUT"
-        else
-          echo "::notice::Using explicit role-to-assume input: ${{ inputs.role-to-assume }}"
-          echo "role_to_assume=${{ inputs.role-to-assume }}" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.role-to-assume.outputs.role_to_assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
     - id: resolved-ref
       run: |

--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -13,29 +13,18 @@ inputs:
   ref:
     required: true
     description: 'The git ref to deploy.'
-  region:
-    required: false
-    default: 'eu-west-2'
   ssh-key:
     required: true
     description: 'The SSH key to use for fetching modules from github.'
   role-to-assume:
     description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
+  region:
     required: false
-    default: ''
+    default: 'eu-west-2'
 runs:
   using: 'composite'
   steps:
-    - id: role-to-assume
-      run: |
-        if [ -z "${{ inputs.role-to-assume }}" ]; then
-          echo "::warning::Falling back to IAM_ROLE_ARN environment variable. Please update to use role-to-assume input."
-          echo "role_to_assume=$IAM_ROLE_ARN" >> "$GITHUB_OUTPUT"
-        else
-          echo "::notice::Using explicit role-to-assume input: ${{ inputs.role-to-assume }}"
-          echo "role_to_assume=${{ inputs.role-to-assume }}" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
     - id: resolved-ref
       run: |
         REF=${{ inputs.ref }}
@@ -52,7 +41,7 @@ runs:
     - uses: actions/checkout@v4.1.0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.role-to-assume.outputs.role_to_assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
     - uses: hashicorp/setup-terraform@v3
       with:

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -16,26 +16,15 @@ inputs:
   ssh-key:
     required: true
     description: 'The SSH key to use for fetching modules from github.'
+  role-to-assume:
+    description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
   region:
     required: false
     default: 'eu-west-2'
-  role-to-assume:
-    description: 'The IAM role ARN to assume for AWS operations.'
-    required: false
-    default: ''
 runs:
   using: 'composite'
   steps:
-    - id: role-to-assume
-      run: |
-        if [ -z "${{ inputs.role-to-assume }}" ]; then
-          echo "::warning::Falling back to IAM_ROLE_ARN environment variable. Please update to use role-to-assume input."
-          echo "role_to_assume=$IAM_ROLE_ARN" >> "$GITHUB_OUTPUT"
-        else
-          echo "::notice::Using explicit role-to-assume input: ${{ inputs.role-to-assume }}"
-          echo "role_to_assume=${{ inputs.role-to-assume }}" >> "$GITHUB_OUTPUT"
-        fi
-      shell: bash
     - id: resolved-ref
       run: |
         REF=${{ inputs.ref }}
@@ -52,7 +41,7 @@ runs:
     - uses: actions/checkout@v4.1.0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ steps.role-to-assume.outputs.role_to_assume }}
+        role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
     - uses: hashicorp/setup-terraform@v3
       with:


### PR DESCRIPTION
### Jira link

[HMRC-1306](https://transformuk.atlassian.net/browse/HMRC-1306)

### What?

I have added/removed/altered:

- [x] Removed support for implicit passing of iam role arn

### Why?

I am doing this because:

- We support explicit passing which makes more sense for an action rather than effectively using a global variable
