### PR TITLE
HMRC-1306: Adds a workflow to stop all services in development

### DIFF
--- a/.github/workflows/stop-development-services.yml
+++ b/.github/workflows/stop-development-services.yml
@@ -1,0 +1,19 @@
+name: Stop Development Services
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 17 * * *'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  stop-services:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/stop-services@main
+        with:
+          service-names: backend-uk backend-xi worker-uk worker-xi backend-job admin frontend identity dev-hub tea
+          environment: development


### PR DESCRIPTION
### Jira link

[HMRC-1306](https://transformuk.atlassian.net/browse/HMRC-1306)

### What?

I have added/removed/altered:

- [x] Added workflow to stop all services in the development environment

### Why?

I am doing this because:

- This is necessary to cut costs and leave development in a mostly on-demand/dormant state
