### PR TITLE
Enable cleanup workflow to remove labels in another repo

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -13,7 +13,6 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
   cleanup:
@@ -27,7 +26,7 @@ jobs:
       AWS_REGION: eu-west-2
       IAM_ROLE_ARN: arn:aws:iam::844815912454:role/GithubActions-Preview-App-Role
       PREEVY_PROFILE_URL: s3://preevy-profile-store?region=eu-west-2
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.BOT_USER_PAT }}
 
     steps:
       - uses: actions/checkout@v4
@@ -40,10 +39,6 @@ jobs:
 
       - name: Lock Docker Compose to v2.36.0
         uses: ./.github/actions/lock-docker-compose
-
-      - uses: ./.github/actions/setup-ssh
-        with:
-          ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
       - run: npm install -g preevy
 


### PR DESCRIPTION
### Jira link


### What?

I have added/removed/altered:

- [x] Added BOT_USER_PAT to enable cleanup workflow to remove labels in another repo

### Why?

I am doing this because:

- It is needed so the workflow can remove  PR labels (needs-preview) from other repositories
