### PR TITLE
HMRC-1380: Support repo and ref as inputs to ecs deployment workflow

### DIFF
--- a/.github/actions/build-and-push/action.yml
+++ b/.github/actions/build-and-push/action.yml
@@ -22,19 +22,6 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
-    - id: resolved-ref
-      run: |
-        REF=${{ inputs.ref }}
-
-        if ! git rev-parse --verify "$REF" 2>/dev/null; then
-          echo "::error::The ref $REF does not exist in the Git repository."
-          exit 1
-        else
-          echo "::notice::Resolved ref: $(git rev-parse --short "$REF")"
-        fi
-
-        echo RESOLVED_REF=$(git rev-parse --short "$REF") >> "$GITHUB_OUTPUT"
-      shell: bash
     - id: extract-build-args
       run: |
         build_args=""
@@ -49,7 +36,7 @@ runs:
         # Extract repository name and registry id from ecr-url (assumes format: <account>.dkr.ecr.<region>.amazonaws.com/<repo>)
         REPO_NAME=$(echo "${{ inputs.ecr-url }}" | cut -d'/' -f2)
         REGISTRY_ID=$(echo "${{ inputs.ecr-url }}" | cut -d'.' -f1)
-        REF=${{ steps.resolved-ref.outputs.RESOLVED_REF }}
+        REF=${{ inputs.ref }}
         IMAGE_NAME="${{ inputs.ecr-url }}:$REF"
 
         aws ecr get-login-password --region ${{ inputs.region }} \

--- a/.github/actions/tag-production/action.yml
+++ b/.github/actions/tag-production/action.yml
@@ -19,22 +19,9 @@ runs:
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
-    - id: resolved-ref
-      run: |
-        REF=${{ inputs.ref }}
-
-        if ! git rev-parse --verify "$REF" 2>/dev/null; then
-          echo "::error::The ref $REF does not exist in the Git repository."
-          exit 1
-        else
-          echo "::notice::Resolved ref: $(git rev-parse --short "$REF")"
-        fi
-
-        echo RESOLVED_REF=$(git rev-parse --short "$REF") >> "$GITHUB_OUTPUT"
-      shell: bash
     - run: |
         REPO_NAME=$(echo "${{ inputs.ecr-url }}" | cut -d'/' -f2)
-        REF=${{ steps.resolved-ref.outputs.RESOLVED_REF }}
+        REF=${{ inputs.ref }}
         EXISTING_IMAGE_NAME="${{ inputs.ecr-url }}:$REF"
 
         aws ecr get-login-password --region ${{ inputs.region }} \

--- a/.github/actions/terraform-apply/action.yml
+++ b/.github/actions/terraform-apply/action.yml
@@ -25,20 +25,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - id: resolved-ref
-      run: |
-        REF=${{ inputs.ref }}
-
-        if ! git rev-parse --verify "$REF" 2>/dev/null; then
-          echo "::error::The ref $REF does not exist in the Git repository."
-          exit 1
-        else
-          echo "::notice::Resolved ref: $(git rev-parse --short "$REF")"
-        fi
-
-        echo RESOLVED_REF=$(git rev-parse --short "$REF") >> "$GITHUB_OUTPUT"
-      shell: bash
-    - uses: actions/checkout@v4.1.0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
@@ -54,4 +40,4 @@ runs:
     - run: cd terraform && terraform apply -var-file=config_${{ inputs.environment }}.tfvars -auto-approve -lock-timeout=10m
       shell: bash
       env:
-        TF_VAR_docker_tag: ${{ steps.resolved-ref.outputs.RESOLVED_REF }}
+        TF_VAR_docker_tag: ${{ inputs.ref }}

--- a/.github/actions/terraform-plan/action.yml
+++ b/.github/actions/terraform-plan/action.yml
@@ -25,20 +25,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - id: resolved-ref
-      run: |
-        REF=${{ inputs.ref }}
-
-        if ! git rev-parse --verify "$REF" 2>/dev/null; then
-          echo "::error::The ref $REF does not exist in the Git repository."
-          exit 1
-        else
-          echo "::notice::Resolved ref: $(git rev-parse --short "$REF")"
-        fi
-
-        echo RESOLVED_REF=$(git rev-parse --short "$REF") >> "$GITHUB_OUTPUT"
-      shell: bash
-    - uses: actions/checkout@v4.1.0
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
@@ -54,4 +40,4 @@ runs:
     - run: cd terraform && terraform plan -var-file=config_${{ inputs.environment }}.tfvars
       shell: bash
       env:
-        TF_VAR_docker_tag: ${{ steps.resolved-ref.outputs.RESOLVED_REF }}
+        TF_VAR_docker_tag: ${{ inputs.ref }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -21,6 +21,16 @@ on:
         type: string
         default: ''
         required: false
+      checkout-repo:
+        description: The repository to checkout (defaults to current repo)
+        type: string
+        default: ''
+        required: false
+      checkout-ref:
+        description: The ref to checkout (defaults to current ref)
+        type: string
+        default: ''
+        required: false
     secrets:
       ssh-key:
         description: The SSH key to use for accessing github repos (implicitly with terraform init)
@@ -49,8 +59,14 @@ jobs:
       ruby_version: ${{ steps.config.outputs.ruby_version }}
       slack_channel: ${{ steps.config.outputs.slack_channel }}
       test_url: ${{ steps.config.outputs.test_url }}
+      actual_repo: ${{ steps.config.outputs.actual_repo }}
+      actual_ref: ${{ steps.config.outputs.actual_ref }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.checkout-repo || github.repository }}
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
       - id: config
         run: |
           case "${{ inputs.environment }}" in
@@ -78,14 +94,26 @@ jobs:
               ;;
           esac
 
+          ACTUAL_REF="${{ inputs.checkout-ref || github.ref }}"
+          ACTUAL_REPO="${{ inputs.checkout-repo || github.repository }}"
+
+          if ! git rev-parse --verify "$ACTUAL_REF" 2>/dev/null; then
+            echo "::error::The ref $ACTUAL_REF does not exist in the Git repository."
+            exit 1
+          else
+            echo "::notice::Resolved ref: $(git rev-parse --short "$ACTUAL_REF")"
+          fi
+
           {
             echo "admin_test_url=${ADMIN_TEST_URL}"
-            echo "docker_tag=$(git rev-parse --short HEAD)"
+            echo "docker_tag=$(git rev-parse --short "$ACTUAL_REF")"
             echo "ecr_url=382373577178.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.app-name }}-production"
             echo "iam_role_arn=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-ECS-Deployments-Role"
             echo "ruby_version=$(cat .ruby-version)"
             echo "slack_channel=${SLACK_CHANNEL}"
             echo "test_url=${TEST_URL}"
+            echo "actual_ref=${ACTUAL_REF}"
+            echo "actual_repo=${ACTUAL_REPO}"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -93,6 +121,9 @@ jobs:
     needs: configure
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.configure.outputs.actual_repo }}
+          ref: ${{ needs.configure.outputs.actual_ref }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-plan@main
         with:
           environment: ${{ inputs.environment }}
@@ -113,6 +144,9 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.configure.outputs.actual_repo }}
+          ref: ${{ needs.configure.outputs.actual_ref }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-apply@main
         with:
           environment: ${{ inputs.environment }}
@@ -128,6 +162,9 @@ jobs:
       - deploy
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.configure.outputs.actual_repo }}
+          ref: ${{ needs.configure.outputs.actual_ref }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/tag-production@main
         with:
           ecr-url: ${{ needs.configure.outputs.ecr_url }}
@@ -166,6 +203,9 @@ jobs:
       - e2e-test-fpo
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.configure.outputs.actual_repo }}
+          ref: ${{ needs.configure.outputs.actual_ref }}
       - id: result
         run: |
           TEST_FLAVOUR="${{ inputs.test-flavour }}"


### PR DESCRIPTION
### Jira link

[HMRC-1380](https://transformuk.atlassian.net/browse/HMRC-1380)

### What?

I have added/removed/altered:

- [x] Added support for input repo and ref to the ecs deployment repository

### Why?

I am doing this because:

- This will enable configurable matrices of multi-app deployments with e2e tests
