### PR TITLE
BAU: Adds support for github-token option in tflint action

### DIFF
--- a/.github/actions/setup-tflint/action.yml
+++ b/.github/actions/setup-tflint/action.yml
@@ -1,9 +1,21 @@
 name: 'Setup TFLint'
 description: 'Setup TFLint for linting Terraform code'
 
+inputs:
+  github-token:
+    description: 'GitHub token for API authentication'
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:
-    - run: |
-        curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+    - name: Install TFLint
+      run: |
+        if [ -n "${{ inputs.github-token }}" ]; then
+          curl -s -H "Authorization: token ${{ inputs.github-token }}" \
+            https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+        else
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+        fi
       shell: bash


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added input for github-token when fetching tflint installation scripts
