### PR TITLE
HMRC-2110: Update db-migrate to cover backend repo only

### DIFF
--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -13,6 +13,9 @@ inputs:
   region:
     required: false
     default: 'eu-west-2'
+  ref:
+    required: true
+    description: 'The git ref to deploy.'
   role-to-assume:
     description: 'The IAM role ARN to assume for AWS operations.'
     required: true
@@ -38,7 +41,7 @@ runs:
     - name: Deploy backend-job
       shell: bash
       env:
-        TF_VAR_docker_tag: $GITHUB_SHA
+        TF_VAR_docker_tag: ${{ inputs.ref }}
       run: |
         cd terraform && terraform apply \
           -var-file=config_${{ inputs.environment }}.tfvars \

--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -1,6 +1,11 @@
 name: 'Run database migrations'
 description: 'Applies schema changes pre-deployment.'
 
+env:
+  TF_INPUT: 0
+  TF_IN_AUTOMATION: 1
+  TERRAFORM_VERSION: 1.12
+
 inputs:
   environment:
     description: 'The name of the environment to perform the migration in'
@@ -11,12 +16,7 @@ inputs:
   role-to-assume:
     description: 'The IAM role ARN to assume for AWS operations.'
     required: true
-  migration-task:
-    description: 'The name of the task to use'
-    required: true
-  migration-overrides:
-    description: 'Container overrides for running the task in JSON format.'
-    required: true
+
 runs:
   using: 'composite'
   steps:
@@ -27,10 +27,51 @@ runs:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.region }}
 
-    - name: Apply database migration
+    - uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: ${{ env.TERRAFORM_VERSION }}
+
+    - name: Initialise Terraform
+      shell: bash
+      run: cd terraform && terraform init -backend-config=backends/${{ inputs.environment }}.tfbackend
+
+    - name: Deploy backend-job
+      shell: bash
+      env:
+        TF_VAR_docker_tag: $GITHUB_SHA
+      run: |
+        cd terraform && terraform apply \
+          -var-file=config_${{ inputs.environment }}.tfvars \
+          -auto-approve \
+          -lock-timeout=10m \
+          -target=module.backend-job
+
+    - name: Apply database migration for UK schema
       shell: bash
       run: |
-        echo "::notice::Running migration task for ${{ inputs.environment }}..."
-        overrides=$(jq -r -c '.' <<<'${{ toJSON(inputs.migration-overrides) }}')
+        echo "::notice::Running migration task for UK schema in ${{ inputs.environment }}..."
 
-        ${{ github.action_path }}/../../../bin/run-task -e ${{ inputs.environment }} -t ${{ inputs.migration-task }} -o "${overrides}"
+        ${{ github.action_path }}/../../../bin/run-task \
+          -e ${{ inputs.environment }} \
+          -t "backend-job" \
+          -o '{"containerOverrides":[{"name":"backend-job","environment":[{"name":"SERVICE","value":"uk"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
+
+    - name: Apply database migration for XI schema
+      shell: bash
+      run: |
+        echo "::notice::Running migration task for XI schema in ${{ inputs.environment }}..."
+
+        ${{ github.action_path }}/../../../bin/run-task \
+          -e ${{ inputs.environment }} \
+          -t "backend-job" \
+          -o '{"containerOverrides":[{"name":"backend-job","environment":[{"name":"SERVICE","value":"xi"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
+
+    - name: Force unlock terraform state on cancellation
+      if: cancelled()
+      shell: bash
+      run: |
+        BUCKET=$(grep '^bucket' terraform/backends/${{ inputs.environment }}.tfbackend | awk -F'"' '{print $2}')
+        KEY=$(grep '^key' terraform/backends/${{ inputs.environment }}.tfbackend | awk -F'"' '{print $2}')
+        aws s3 cp "s3://${BUCKET}/${KEY}.tflock" /tmp/terraform.tflock || exit 0
+        LOCK_ID=$(jq -r '.ID' /tmp/terraform.tflock)
+        cd terraform && terraform force-unlock -force "${LOCK_ID}"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -36,20 +36,12 @@ on:
         type: boolean
         default: false
         required: false
-      migration-task:
-        description: Name of the task to use for migration
-        type: string
-        default: ''
-        required: false
-      migration-overrides:
-        description: Migration job container overrides, in JSON format.
-        type: string
-        required: false
       notify:
         description: Whether to send notifications to Slack
         type: boolean
         default: true
         required: false
+
     secrets:
       ssh-key:
         description: The SSH key to use for accessing github repos (implicitly with terraform init)
@@ -172,11 +164,9 @@ jobs:
           repository: ${{ needs.configure.outputs.actual_repo }}
           ref: ${{ needs.configure.outputs.actual_ref }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/db-migrate@main
-        if: ${{ inputs.migrate }}
+        if: ${{ inputs.migrate &&  needs.configure.outputs.actual_repo == 'trade-tariff/trade-tariff-backend' }}
         with:
           environment: ${{ inputs.environment }}
-          migration-task: ${{ inputs.migration-task }}
-          migration-overrides: ${{ inputs.migration-overrides }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-apply@main
         with:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -167,6 +167,7 @@ jobs:
         if: ${{ inputs.migrate &&  needs.configure.outputs.actual_repo == 'trade-tariff/trade-tariff-backend' }}
         with:
           environment: ${{ inputs.environment }}
+          ref: ${{ needs.configure.outputs.docker_tag }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/terraform-apply@main
         with:

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -15,6 +15,12 @@ on:
         description: "The flavour of tests to run. Options: 'tariff', 'fpo', 'none'"
         type: string
         default: tariff
+      migrate:
+        description: Whether to run database migrations before deployment
+        type: boolean
+        default: false
+        required: false
+
     secrets:
       ssh-key:
         required: true
@@ -53,11 +59,12 @@ jobs:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/deploy-ecs.yml@main
     with:
       app-name: ${{ matrix.app.name }}
-      environment: ${{ inputs.environment }}
-      test-flavour: none
       checkout-ref: ${{ matrix.app.ref }}
       checkout-repo: ${{ matrix.app.repo }}
+      environment: ${{ inputs.environment }}
+      migrate: ${{ inputs.migrate }}
       notify: false
+      test-flavour: none
     secrets:
       ssh-key: ${{ secrets.ssh-key }}
       slack-webhook: ${{ secrets.slack-webhook }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -9,17 +9,17 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
         args: ["--severity=error"]
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.7
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.20
+    rev: v3.94.3
     hooks:
       - id: trufflehog


### PR DESCRIPTION
### Jira link

[HMRC-2110](https://transformuk.atlassian.net/browse/HMRC-2110)

### What?

I have added/removed/altered:

- Updated `db-migrate` action to use a special-case database migration strategy for the backend service.

### Why?

I am doing this because:

- `trade-tariff-admin` and `trade-tariff-dev-hub` both connect to databases, but implicitly have an init container that runs database migrations. They can do this because, unlike `trade-tariff-backend`, they are not split into multiple types of container (`api`/`worker`). In their case, database migrations run cleanly before service deployment due to this init container paradigm.

- In the case of `trade-tariff-backend`, the init container does run in the worker instances to perform database migrations - but because there is no "stop and wait" mechanism in the API instances, they may be deployed and run with code that depends on migrations to have occured first.

- This PR adds a special case migration task for the backend service. Firstly, we perform a targeted deploy of the `backend-job` service, so that the new application code is in ECS. Then we run the database migration, once for each schema (UK/XI).

- This migration task only runs if the checked out repo is `trade-tariff-backend`, AND the input `migrate` is `true`; this allows us to turn this on and test it before committing to using this in production workflows.