### PR TITLE
BAU: Update terraform-docs version in CI

### DIFF
--- a/.github/actions/setup-terraform-docs/action.yml
+++ b/.github/actions/setup-terraform-docs/action.yml
@@ -4,7 +4,7 @@ description: 'Setup terraform docs'
 inputs:
   terraform_docs_version:
     required: false
-    default: '0.20.0'
+    default: '0.22.0'
 
 runs:
   using: 'composite'


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Bumped version of `terraform-docs`

### Why?

I am doing this because:

- `terraform-docs` is now at v0.22.0, and any changes made using this version on local machines will cause lint failures in CI