### PR TITLE
Fix broken db-migrate action

### DIFF
--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -24,6 +24,7 @@ runs:
   using: 'composite'
   steps:
     - name: Configure output variables
+      shell: bash
       id: configure
       run: |
         REPO=$(echo ${{ github.repository }} | sed 's/trade-tariff\/trade-tariff-//')


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added missing `shell` label

### Why?

I am doing this because:

- The action was broken
- The linter didn't pick up on this (??)
