### PR TITLE
BAU: Always use TF_IN_AUTOMATION and TF_INPUT

### DIFF
--- a/.github/actions/terraform-plan-comment/action.yml
+++ b/.github/actions/terraform-plan-comment/action.yml
@@ -1,6 +1,11 @@
 name: 'Terraform Plan Comment'
 description: 'Posts Terraform plan with destroy detection to PR comments'
 
+env:
+  TF_INPUT: 0
+  TF_IN_AUTOMATION: 1
+  TERRAFORM_VERSION: 1.12
+
 inputs:
   plan-json-path:
     description: 'Path to terraform plan JSON file'


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added `TF_INPUT: 0` and `TF_IN_AUTOMATION: 1` to Terraform plan comment workflow.

### Why?

I am doing this because:

- When Terraform is running in CI, we should always set these variables. This stops execution when variables are unset, for instance.