### PR TITLE
Altered deploy-ecs.yml so app-name: tariff-identity uses GithubActions-Identity-ECS-Deployments-Role instead of GithubActions-ECS-Deployments-Role

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -119,9 +119,15 @@ jobs:
           esac
 
 
+          if [ "${{ inputs.app-name }}" = "tariff-identity" ]; then
+            DEPLOY_ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
+          else
+            DEPLOY_ROLE_NAME="GithubActions-ECS-Deployments-Role"
+          fi
+
           {
             echo "ecr_url=382373577178.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.app-name }}-production"
-            echo "iam_role_arn=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-ECS-Deployments-Role"
+            echo "iam_role_arn=arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOY_ROLE_NAME}"
             echo "ruby_version=$(cat .ruby-version)"
             echo "slack_channel=${SLACK_CHANNEL}"
             echo "docker_tag=$(git rev-parse --short HEAD)"


### PR DESCRIPTION
### Jira link

OTTIMP-536

What?
I have:

Altered deploy-ecs.yml so app-name: tariff-identity uses GithubActions-Identity-ECS-Deployments-Role instead of GithubActions-ECS-Deployments-Role
Why?
I am doing this because:

Platform Terraform defines a dedicated identity ECS + Lambda deploy role; the deploy workflow must assume that role for identity builds and Terraform apply
Other ECS apps are unchanged and keep the existing ECS deployments role
Depends on
GithubActions-Identity-ECS-Deployments-Role must exist in the target AWS account (platform Terraform applied first)
