### PR TITLE
Use identity ECS role for identity service

### DIFF
--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -35,7 +35,15 @@ runs:
             ;;
         esac
 
-        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-ECS-Deployments-Role" >> "$GITHUB_OUTPUT"
+        ROLE_NAME="GithubActions-ECS-Deployments-Role"
+        for SERVICE_NAME in ${{ inputs.service-names }}; do
+          if [ "$SERVICE_NAME" = "identity" ]; then
+            ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
+            break
+          fi
+        done
+
+        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" >> "$GITHUB_OUTPUT"
       shell: bash
     - uses: aws-actions/configure-aws-credentials@v6
       with:

--- a/.github/actions/stop-services/action.yml
+++ b/.github/actions/stop-services/action.yml
@@ -32,7 +32,15 @@ runs:
             ;;
         esac
 
-        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-ECS-Deployments-Role" >> "$GITHUB_OUTPUT"
+        ROLE_NAME="GithubActions-ECS-Deployments-Role"
+        for SERVICE_NAME in ${{ inputs.service-names }}; do
+          if [ "$SERVICE_NAME" = "identity" ]; then
+            ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
+            break
+          fi
+        done
+
+        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" >> "$GITHUB_OUTPUT"
       shell: bash
     - uses: aws-actions/configure-aws-credentials@v6
       with:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/OTTIMP-616

### What?
I have added/removed/altered:

- Updated start-services to use GithubActions-Identity-ECS-Deployments-Role when starting the identity ECS service
- Updated stop-services with the same role selection logic for consistency

### Why?
I am doing this because:

- Identity deploy workflows call start-services@main, which always assumed GithubActions-ECS-Deployments-Role
- That role does not trust repo:trade-tariff/identity:*, so OIDC failed with Not authorized to perform sts:AssumeRoleWithWebIdentity
- deploy-ecs.yml already uses GithubActions-Identity-ECS-Deployments-Role for tariff-identity; this aligns start-services / stop-services with that behaviour
