### PR TITLE
HMRC-2246: Investigate adding a failing PR check for large pull requests (600+ lines)

### DIFF
--- a/.github/actions/check-pr-lines/action.yml
+++ b/.github/actions/check-pr-lines/action.yml
@@ -1,0 +1,84 @@
+name: Check PR line count
+description: >-
+  Fail when a pull request changes more lines than the configured threshold.
+  Supports pull_request and push events (push looks up the open PR for the branch).
+
+inputs:
+  threshold:
+    description: Maximum allowed lines changed (additions + deletions).
+    required: true
+  exclude-paths:
+    description: >-
+      Newline-separated path globs to exclude from the count (git pathspec syntax).
+      Lines starting with # are ignored.
+    required: false
+    default: ''
+  base-sha:
+    description: Override the base commit SHA (optional).
+    required: false
+    default: ''
+  head-sha:
+    description: Override the head commit SHA (optional).
+    required: false
+    default: ''
+  github-token:
+    description: Token used to resolve the open PR on push events.
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        THRESHOLD: ${{ inputs.threshold }}
+        EXCLUDE_PATHS: ${{ inputs.exclude-paths }}
+        INPUT_BASE_SHA: ${{ inputs.base-sha }}
+        INPUT_HEAD_SHA: ${{ inputs.head-sha }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        base_sha="$INPUT_BASE_SHA"
+        head_sha="$INPUT_HEAD_SHA"
+
+        if [[ -z "$base_sha" || -z "$head_sha" ]]; then
+          case "${{ github.event_name }}" in
+            pull_request)
+              base_sha="${{ github.event.pull_request.base.sha }}"
+              head_sha="${{ github.event.pull_request.head.sha }}"
+              ;;
+            push)
+              response="$(
+                curl -fsSL \
+                  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/${{ github.repository }}/pulls?head=${{ github.repository_owner }}:${{ github.ref_name }}&state=open"
+              )"
+              if [[ "$(jq 'length' <<< "$response")" -eq 0 ]]; then
+                echo "::notice::No open pull request for ${{ github.ref_name }}; skipping line check."
+                exit 0
+              fi
+              base_sha="$(jq -r '.[0].base.sha' <<< "$response")"
+              head_sha="$(jq -r '.[0].head.sha' <<< "$response")"
+              ;;
+            *)
+              echo "::error::Unsupported event: ${{ github.event_name }}. Use pull_request or push." >&2
+              exit 1
+              ;;
+          esac
+        fi
+
+        if [[ -z "$base_sha" || -z "$head_sha" ]]; then
+          echo "::error::Could not determine base-sha and head-sha." >&2
+          exit 1
+        fi
+
+        exclude_file="$(mktemp)"
+        printf '%s\n' "$EXCLUDE_PATHS" > "$exclude_file"
+
+        "${{ github.action_path }}/check-pr-lines.sh" \
+          --threshold "$THRESHOLD" \
+          --base "$base_sha" \
+          --head "$head_sha" \
+          --exclude-paths-file "$exclude_file"

--- a/.github/actions/check-pr-lines/check-pr-lines.sh
+++ b/.github/actions/check-pr-lines/check-pr-lines.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-pr-lines.sh --threshold <n> --base <sha> --head <sha> [--exclude-paths-file <file>]
+
+Counts additions and deletions between two commits (after optional path exclusions)
+and exits 1 when the total exceeds the threshold.
+EOF
+}
+
+threshold=""
+base_sha=""
+head_sha=""
+exclude_paths_file=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --threshold)
+      threshold="$2"
+      shift 2
+      ;;
+    --base)
+      base_sha="$2"
+      shift 2
+      ;;
+    --head)
+      head_sha="$2"
+      shift 2
+      ;;
+    --exclude-paths-file)
+      exclude_paths_file="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$threshold" || -z "$base_sha" || -z "$head_sha" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
+  echo "threshold must be a non-negative integer, got: $threshold" >&2
+  exit 2
+fi
+
+exclude_specs=()
+if [[ -n "$exclude_paths_file" && -f "$exclude_paths_file" ]]; then
+  while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [[ -z "$pattern" || "$pattern" == \#* ]] && continue
+    exclude_specs+=(":(exclude)${pattern}")
+  done < "$exclude_paths_file"
+fi
+
+if ((${#exclude_specs[@]} > 0)); then
+  numstat="$(git diff --numstat "$base_sha" "$head_sha" -- . "${exclude_specs[@]}")"
+else
+  numstat="$(git diff --numstat "$base_sha" "$head_sha" -- .)"
+fi
+
+total=0
+if [[ -n "$numstat" ]]; then
+  while IFS=$'\t' read -r added removed _file; do
+    [[ -z "$added" || "$added" == "-" ]] && continue
+    total=$((total + added + removed))
+  done <<< "$numstat"
+fi
+
+echo "PR changes ${total} lines (threshold: ${threshold})"
+
+{
+  echo "## PR line count"
+  echo ""
+  echo "| Metric | Value |"
+  echo "| --- | ---: |"
+  echo "| Lines changed | ${total} |"
+  echo "| Threshold | ${threshold} |"
+} >> "${GITHUB_STEP_SUMMARY:-/dev/null}" 2>/dev/null || true
+
+if (( total > threshold )); then
+  echo "::error::PR changes ${total} lines, which exceeds the limit of ${threshold}." >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/ci.yml'
       - 'bin/cleanup-ecs-families'
       - 'bin/rotate-revisions'
+      - '.github/actions/check-pr-lines/**'
       - 'scripts/trufflehog-pre-commit.sh'
       - 'tests/**'
 
@@ -25,7 +26,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/trufflehog-pre-commit.sh bin/cleanup-ecs-families bin/rotate-revisions tests/test_helper.bash
+        run: bash -n scripts/trufflehog-pre-commit.sh .github/actions/check-pr-lines/check-pr-lines.sh bin/cleanup-ecs-families bin/rotate-revisions tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/tests/check-pr-lines.bats
+++ b/tests/check-pr-lines.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  repo="$(mktemp -d)"
+  script="${BATS_TEST_DIRNAME}/../.github/actions/check-pr-lines/check-pr-lines.sh"
+  [[ -f "$script" ]] || fail "missing ${script}"
+
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" config user.name "Test User"
+
+  printf 'base\n' > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -qm "base"
+  base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  printf 'base\nchanged\n' > "$repo/file.txt"
+  git -C "$repo" add file.txt
+  git -C "$repo" commit -qm "head"
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+}
+
+teardown() {
+  rm -rf "$repo"
+}
+
+@test "passes when changes are within threshold" {
+  cd "$repo" || return 1
+  run bash "$script" --threshold 10 --base "$base_sha" --head "$head_sha"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR changes 1 lines"* ]]
+}
+
+@test "fails when changes exceed threshold" {
+  cd "$repo" || return 1
+  run bash "$script" --threshold 0 --base "$base_sha" --head "$head_sha"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"exceeds the limit"* ]]
+}
+
+@test "excludes paths from the line count" {
+  printf 'noise\n' > "$repo/ignored.lock"
+  git -C "$repo" add ignored.lock
+  git -C "$repo" commit -qm "add lockfile"
+  head_with_lock="$(git -C "$repo" rev-parse HEAD)"
+
+  exclude_file="$(mktemp)"
+  printf '%s\n' '*.lock' > "$exclude_file"
+
+  cd "$repo" || return 1
+
+  run bash "$script" \
+    --threshold 1 \
+    --base "$base_sha" \
+    --head "$head_with_lock"
+  [ "$status" -eq 1 ]
+
+  run bash "$script" \
+    --threshold 1 \
+    --base "$base_sha" \
+    --head "$head_with_lock" \
+    --exclude-paths-file "$exclude_file"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR changes 1 lines"* ]]
+
+  rm -f "$exclude_file"
+}


### PR DESCRIPTION
### Jira link

[OTT-<TODO>](https://transformuk.atlassian.net/browse/HMRC-2246)

### What?

I have added/removed/altered:

- [ ] Added new github action to check pr line count fail big pr


### Why?

I am doing this because:

- Large pull requests are harder to review thoroughly, increase the risk of bugs slipping through, and slow down the review cycle. A hard check on PR size will guide contributors to break up their work into smaller, more manageable chunks.

### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
