### PR TITLE
BAU: Use updated migration task definition

### DIFF
--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -49,15 +49,28 @@ runs:
       run: cd terraform && terraform init -backend-config=backends/${{ inputs.environment }}.tfbackend
 
     - name: Update job task
+      id: update-job-task
       shell: bash
       env:
         TF_VAR_docker_tag: ${{ inputs.ref }}
       run: |
-        cd terraform && terraform apply \
+        cd terraform
+
+        terraform apply \
           -var-file=config_${{ inputs.environment }}.tfvars \
           -auto-approve \
           -lock-timeout=10m \
           -target=module.${{ steps.configure.outputs.task }}
+
+        task_definition_arn=$(terraform state show "module.${{ steps.configure.outputs.task }}.aws_ecs_task_definition.this" \
+          | awk -F'= ' '/^[[:space:]]*arn[[:space:]]+=/ { gsub(/"/, "", $2); print $2; exit }')
+
+        if [ -z "${task_definition_arn}" ]; then
+          echo "::error::Could not determine updated task definition ARN"
+          exit 1
+        fi
+
+        echo "task-definition-arn=${task_definition_arn}" >> "$GITHUB_OUTPUT"
 
     # For the admin and dev-hub services, there is only one search path to
     # apply migrations to, so this runs one task
@@ -70,6 +83,7 @@ runs:
         ${{ github.action_path }}/../../../bin/run-task \
           -e ${{ inputs.environment }} \
           -t ${{ steps.configure.outputs.task }} \
+          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
           -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","command":["/bin/sh","-c","bundle exec rails db:migrate"]}]}'
 
     # The backend service needs to run database migrations twice, once for each
@@ -82,12 +96,14 @@ runs:
         ${{ github.action_path }}/../../../bin/run-task \
           -e ${{ inputs.environment }} \
           -t ${{ steps.configure.outputs.task }} \
+          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
           -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","environment":[{"name":"SERVICE","value":"uk"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
 
         echo "::notice::Running migration task for XI schema in ${{ inputs.environment }}..."
         ${{ github.action_path }}/../../../bin/run-task \
           -e ${{ inputs.environment }} \
           -t ${{ steps.configure.outputs.task }} \
+          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
           -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","environment":[{"name":"SERVICE","value":"xi"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
 
     - name: Force unlock terraform state on cancellation

--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -7,6 +7,9 @@ env:
   TERRAFORM_VERSION: 1.12
 
 inputs:
+  app-name:
+    description: 'The app being deployed, for example tariff-backend or tariff-dev-hub.'
+    required: true
   environment:
     description: 'The name of the environment to perform the migration in'
     required: true
@@ -27,13 +30,12 @@ runs:
       shell: bash
       id: configure
       run: |
-        REPO=$(echo ${{ github.repository }} | sed 's/trade-tariff\/trade-tariff-//')
+        REPO="${{ inputs.app-name }}"
+        REPO="${REPO#tariff-}"
         {
-          echo "repo_name=${REPO}"
+          echo "repo=${REPO}"
           echo "task=${REPO}-job"
         } >> "$GITHUB_OUTPUT"
-
-    - uses: actions/checkout@v6
 
     - uses: aws-actions/configure-aws-credentials@v6
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - '.github/workflows/ci.yml'
       - '.github/workflows/close-stale-pull-requests-reusable.yml'
+      - '.github/actions/db-migrate/**'
       - 'bin/cleanup-ecs-families'
+      - 'bin/run-task'
       - 'bin/rotate-revisions'
       - '.github/actions/check-pr-lines/**'
       - 'scripts/trufflehog-pre-commit.sh'
@@ -27,7 +29,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/trufflehog-pre-commit.sh .github/actions/check-pr-lines/check-pr-lines.sh bin/cleanup-ecs-families bin/rotate-revisions tests/test_helper.bash
+        run: bash -n scripts/trufflehog-pre-commit.sh .github/actions/check-pr-lines/check-pr-lines.sh bin/cleanup-ecs-families bin/run-task bin/rotate-revisions tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -172,6 +172,7 @@ jobs:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/db-migrate@main
         if: ${{ inputs.migrate }}
         with:
+          app-name: ${{ inputs.app-name }}
           environment: ${{ inputs.environment }}
           ref: ${{ needs.configure.outputs.docker_tag }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -62,7 +62,7 @@ jobs:
       checkout-ref: ${{ matrix.app.ref }}
       checkout-repo: ${{ matrix.app.repo }}
       environment: ${{ inputs.environment }}
-      migrate: ${{ inputs.migrate && matrix.app.migrate != false }}
+      migrate: ${{ inputs.migrate && toJson(matrix.app.migrate) != 'false' }}
       notify: false
       test-flavour: none
     secrets:

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -62,7 +62,7 @@ jobs:
       checkout-ref: ${{ matrix.app.ref }}
       checkout-repo: ${{ matrix.app.repo }}
       environment: ${{ inputs.environment }}
-      migrate: ${{ inputs.migrate && toJson(matrix.app.migrate) != 'false' }}
+      migrate: ${{ inputs.migrate && toJson(matrix.app.migrate) == 'true' }}
       notify: false
       test-flavour: none
     secrets:

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -62,7 +62,7 @@ jobs:
       checkout-ref: ${{ matrix.app.ref }}
       checkout-repo: ${{ matrix.app.repo }}
       environment: ${{ inputs.environment }}
-      migrate: ${{ inputs.migrate }}
+      migrate: ${{ inputs.migrate && matrix.app.migrate != false }}
       notify: false
       test-flavour: none
     secrets:

--- a/bin/run-task
+++ b/bin/run-task
@@ -7,8 +7,13 @@ set -o noclobber
 
 readonly SCRIPT_NAME="$(basename "$0")"
 
+environment=""
+task=""
+task_definition=""
+overrides=""
+
 usage() {
-  echo "Usage: ${SCRIPT_NAME} [-e <environment>] [-t <task-name>] [-o <overrides>]" 1>&2;
+  echo "Usage: ${SCRIPT_NAME} [-e <environment>] [-t <task-name>] [-d <task-definition-arn>] [-o <overrides>]" 1>&2;
   exit 1;
 }
 
@@ -22,6 +27,7 @@ OPTIONS:
   -h  Show this help message and exit
   -e  Environment name (one of \`development\`, \`staging\`, \`production\`)
   -t  Name of the task to use. Must be one of the available ECS tasks.
+  -d  Task definition ARN to run. Defaults to the latest active definition for the task.
   -o  Container overrides, in JSON format. See AWS docs for complete documentation.
 
 EXAMPLES:
@@ -29,13 +35,16 @@ EXAMPLES:
 EOF
 }
 
-while getopts ":e:t:o:h" opt; do
+while getopts ":e:t:d:o:h" opt; do
   case "${opt}" in
     e)
       environment=${OPTARG}
       ;;
     t)
       task=${OPTARG}
+      ;;
+    d)
+      task_definition=${OPTARG}
       ;;
     o)
       overrides=${OPTARG}
@@ -88,13 +97,20 @@ run_task() {
     --output text                                   \
     --region "${AWS_REGION}")
 
-  task_definition=$(aws ecs list-task-definitions \
-    --status ACTIVE                               \
-    --sort DESC                                   \
-    --region "${AWS_REGION}"                      \
-  | jq -r '.taskDefinitionArns[]'                 \
-  | grep -E ".*/${task}-[0-9]{12}:[0-9]+$"        \
-  | head -n 1)
+  if [ -z "${task_definition}" ]; then
+    task_definition=$(aws ecs list-task-definitions \
+      --status ACTIVE                               \
+      --sort DESC                                   \
+      --region "${AWS_REGION}"                      \
+    | jq -r '.taskDefinitionArns[]'                 \
+    | grep -E ".*/${task}-[0-9]{12}:[0-9]+$"        \
+    | head -n 1)
+  fi
+
+  if [ -z "${task_definition}" ]; then
+    echo "Could not find an active task definition for ${task}"
+    exit 1
+  fi
 
   task_arn=$(aws ecs run-task              \
     --cluster "${CLUSTER}"                 \

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "db-migrate passes the updated task definition ARN to every migration task" {
+  action="$repo_root/.github/actions/db-migrate/action.yml"
+
+  run grep -F "id: update-job-task" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "task-definition-arn=" "$action"
+  [ "$status" -eq 0 ]
+
+  count=$(grep -F -c -- '-d ${{ steps.update-job-task.outputs.task-definition-arn }}' "$action" || true)
+  [ "$count" -eq 3 ]
+}

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -14,3 +14,33 @@ load test_helper
   count=$(grep -F -c -- '-d ${{ steps.update-job-task.outputs.task-definition-arn }}' "$action" || true)
   [ "$count" -eq 3 ]
 }
+
+@test "db-migrate derives the job task from the deployed app name" {
+  action="$repo_root/.github/actions/db-migrate/action.yml"
+
+  run grep -F "app-name:" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'REPO="${{ inputs.app-name }}"' "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'REPO="${REPO#tariff-}"' "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'echo "repo=${REPO}"' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "db-migrate does not checkout the caller repository" {
+  action="$repo_root/.github/actions/db-migrate/action.yml"
+
+  run grep -F "actions/checkout" "$action"
+  [ "$status" -ne 0 ]
+}
+
+@test "deploy-ecs passes the deployed app name to db-migrate" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "app-name: \${{ inputs.app-name }}" "$workflow"
+  [ "$status" -eq 0 ]
+}

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -44,3 +44,10 @@ load test_helper
   run grep -F "app-name: \${{ inputs.app-name }}" "$workflow"
   [ "$status" -eq 0 ]
 }
+
+@test "deploy-multi-ecs lets individual apps opt out of global migrations" {
+  workflow="$repo_root/.github/workflows/deploy-multi-ecs.yml"
+
+  run grep -F "migrate: \${{ inputs.migrate && matrix.app.migrate != false }}" "$workflow"
+  [ "$status" -eq 0 ]
+}

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -45,9 +45,9 @@ load test_helper
   [ "$status" -eq 0 ]
 }
 
-@test "deploy-multi-ecs lets individual apps opt out of global migrations" {
+@test "deploy-multi-ecs only migrates apps that explicitly opt in" {
   workflow="$repo_root/.github/workflows/deploy-multi-ecs.yml"
 
-  run grep -F "migrate: \${{ inputs.migrate && toJson(matrix.app.migrate) != 'false' }}" "$workflow"
+  run grep -F "migrate: \${{ inputs.migrate && toJson(matrix.app.migrate) == 'true' }}" "$workflow"
   [ "$status" -eq 0 ]
 }

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -48,6 +48,6 @@ load test_helper
 @test "deploy-multi-ecs lets individual apps opt out of global migrations" {
   workflow="$repo_root/.github/workflows/deploy-multi-ecs.yml"
 
-  run grep -F "migrate: \${{ inputs.migrate && matrix.app.migrate != false }}" "$workflow"
+  run grep -F "migrate: \${{ inputs.migrate && toJson(matrix.app.migrate) != 'false' }}" "$workflow"
   [ "$status" -eq 0 ]
 }

--- a/tests/run-task.bats
+++ b/tests/run-task.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  setup_stub_path
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+@test "run-task uses an explicit task definition ARN when supplied" {
+  capture="$tmpdir/capture"
+  mkdir -p "$capture"
+
+  cat > "$stub_bin/aws" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/aws-calls.txt"
+
+case "$1 $2" in
+  "ec2 describe-subnets")
+    printf 'subnet-1,subnet-2'
+    ;;
+  "ec2 describe-security-groups")
+    printf 'sg-123'
+    ;;
+  "ecs run-task")
+    task_definition=""
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "--task-definition" ]]; then
+        task_definition="$2"
+        break
+      fi
+      shift
+    done
+    printf '%s\n' "$task_definition" > "$TEST_CAPTURE_DIR/run-task-definition.txt"
+    printf 'arn:aws:ecs:eu-west-2:123456789012:task/trade-tariff-cluster-development/task-123'
+    ;;
+  "ecs wait")
+    ;;
+  "logs describe-log-streams")
+    printf '{"logStreams":[{"creationTime":1,"logStreamName":"ecs/dev-hub-job/task-123"}]}'
+    ;;
+  "logs get-log-events")
+    printf '["migration ok"]'
+    ;;
+  "ecs describe-tasks")
+    printf '0'
+    ;;
+  "ecs list-task-definitions")
+    echo "run-task should not list task definitions when an explicit ARN is supplied" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected aws command: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/aws"
+
+  explicit_arn="arn:aws:ecs:eu-west-2:123456789012:task-definition/dev-hub-job-123456789012:252"
+
+  run env AWS_REGION=eu-west-2 TEST_CAPTURE_DIR="$capture" "$repo_root/bin/run-task" \
+    -e development \
+    -t dev-hub-job \
+    -d "$explicit_arn" \
+    -o '{"containerOverrides":[{"name":"dev-hub-job"}]}'
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$capture/run-task-definition.txt")" = "$explicit_arn" ]
+  assert_not_contains "$(cat "$capture/aws-calls.txt")" "ecs list-task-definitions"
+}


### PR DESCRIPTION
## What

- Add an explicit task definition ARN option to `bin/run-task`.
- Have the `db-migrate` action capture the task definition ARN from Terraform state after the targeted job task apply.
- Pass that exact ARN into each migration task run.
- Keep `db-migrate` on the repository checked out by `deploy-ecs`, instead of checking out the reusable workflow caller repository.
- Derive the migration job task from the deployed `app-name`, not `github.repository`.
- Make `deploy-multi-ecs` migrations opt-in per app: callers must set the global `migrate: true` input and mark individual database-backed app entries with `"migrate": true`.
- Add Bats coverage for the explicit ARN path, action wiring, checkout behaviour, app-name wiring, and migration opt-in convention.

## Why

Full-stack deployments update each app's job task definition immediately before running migrations. Previously, `bin/run-task` rediscovered the latest active task definition by listing active revisions for the family. That can race ECS eventual consistency after Terraform replaces the revision, selecting a stale image revision or a revision ECS reports as inactive.

Using the ARN Terraform just created pins the migration task to the task definition updated with the deployment image tag.

The first fix was not enough for reusable full-stack deployments because `db-migrate` checked out the caller repository internally. In a `deploy-multi-ecs` run from dev-hub, that meant backend/identity migration jobs could reset the workspace back to `trade-tariff-dev-hub` and apply the wrong Terraform. The action also used reusable-workflow context to infer the repo name, which points at the caller repo rather than the matrix app.

The opt-in migration convention avoids running Rails migrations for apps that are deployed in the stack but do not support this action, such as identity.

## Follow-up caller changes

The new convention needs callers to opt in database-backed apps. Follow-up PRs:

- Backend: https://github.com/trade-tariff/trade-tariff-backend/pull/3218
- Frontend: https://github.com/trade-tariff/trade-tariff-frontend/pull/3068
- Admin: https://github.com/trade-tariff/trade-tariff-admin/pull/1269
