### PR TITLE
BAU- Fix db-migrate app targeting for parallel ECS deploys

### DIFF
--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -7,6 +7,9 @@ env:
   TERRAFORM_VERSION: 1.12
 
 inputs:
+  app-name:
+    description: 'ECR app name (e.g. tariff-dev-hub, tariff-identity)'
+    required: true
   environment:
     description: 'The name of the environment to perform the migration in'
     required: true
@@ -27,13 +30,33 @@ runs:
       shell: bash
       id: configure
       run: |
-        REPO=$(echo ${{ github.repository }} | sed 's/trade-tariff\/trade-tariff-//')
+        case "${{ inputs.app-name }}" in
+          tariff-dev-hub)
+            REPO=dev-hub
+            TASK=dev-hub-job
+            ;;
+          tariff-identity)
+            REPO=identity
+            TASK=identity-job
+            ;;
+          tariff-backend)
+            REPO=backend
+            TASK=backend-job
+            ;;
+          tariff-admin)
+            REPO=admin
+            TASK=admin-job
+            ;;
+          *)
+            echo "::error::Unknown app-name for db-migrate: ${{ inputs.app-name }}"
+            exit 1
+            ;;
+        esac
+
         {
           echo "repo_name=${REPO}"
-          echo "task=${REPO}-job"
+          echo "task=${TASK}"
         } >> "$GITHUB_OUTPUT"
-
-    - uses: actions/checkout@v6
 
     - uses: aws-actions/configure-aws-credentials@v6
       with:
@@ -62,7 +85,7 @@ runs:
     # For the admin and dev-hub services, there is only one search path to
     # apply migrations to, so this runs one task
     - name: Apply database migration
-      if: ${{ steps.configure.outputs.repo != 'backend' }}
+      if: ${{ steps.configure.outputs.repo_name != 'backend' }}
       shell: bash
       run: |
         echo "::notice::Running migration task in ${{ inputs.environment }}..."
@@ -75,7 +98,7 @@ runs:
     # The backend service needs to run database migrations twice, once for each
     # search path - so this custom behaviour runs instead
     - name: Apply database migrations for backend service
-      if: ${{ steps.configure.outputs.repo == 'backend' }}
+      if: ${{ steps.configure.outputs.repo_name == 'backend' }}
       shell: bash
       run: |
         echo "::notice::Running migration task for UK schema in ${{ inputs.environment }}..."

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -151,7 +151,7 @@ jobs:
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/build-and-push@main
         with:
-          build-args: "RUBY_VERSION=${{ needs.configure.outputs.ruby_version }} ALPINE_VERSION=3.22 ${{ inputs.build-args }}"
+          build-args: "RUBY_VERSION=${{ needs.configure.outputs.ruby_version }} ALPINE_VERSION=3.23 ${{ inputs.build-args }}"
           ecr-url: ${{ needs.configure.outputs.ecr_url }}
           ref: ${{ needs.configure.outputs.docker_tag }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
@@ -172,6 +172,7 @@ jobs:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/db-migrate@main
         if: ${{ inputs.migrate }}
         with:
+          app-name: ${{ inputs.app-name }}
           environment: ${{ inputs.environment }}
           ref: ${{ needs.configure.outputs.docker_tag }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -52,6 +52,8 @@ jobs:
           environment: development
 
   deploy-all:
+    needs: start-all
+    if: ${{ always() && (needs.start-all.result == 'success' || needs.start-all.result == 'skipped') }}
     strategy:
       matrix:
         app: ${{ fromJson(inputs.apps) }}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- [x] Added `app-name` input to `db-migrate` and map each app to the correct Terraform job module
- [x] Removed redundant `checkout` from `db-migrate` so deploy keeps the correct repo checkout
- [x] Fixed backend migration condition (`repo_name` instead of `repo`)
- [x] Passed `app-name` from `deploy-ecs` into `db-migrate`
- [x] Made `deploy-all` wait for `start-all` before parallel ECS deploys
- [x] Updated Docker build `ALPINE_VERSION` to 3.23 to match app Dockerfiles

### Why?

I am doing this because:

- Full deploys from dev-hub were running `db-migrate` against dev-hub for every matrix leg (identity/backend), causing conflicting Terraform applies and unstable dev-hub ECS deploys
- Identity and backend migrations were not reliably targeting the right repo or module
- Start-services and deploy were racing in development full deploys
