### PR TITLE
BAU: Fix PR line count merge base

### DIFF
--- a/.github/actions/check-pr-lines/check-pr-lines.sh
+++ b/.github/actions/check-pr-lines/check-pr-lines.sh
@@ -56,6 +56,8 @@ if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+merge_base="$(git merge-base "$base_sha" "$head_sha")"
+
 exclude_specs=()
 if [[ -n "$exclude_paths_file" && -f "$exclude_paths_file" ]]; then
   while IFS= read -r pattern || [[ -n "$pattern" ]]; do
@@ -67,9 +69,9 @@ if [[ -n "$exclude_paths_file" && -f "$exclude_paths_file" ]]; then
 fi
 
 if ((${#exclude_specs[@]} > 0)); then
-  numstat="$(git diff --numstat "$base_sha" "$head_sha" -- . "${exclude_specs[@]}")"
+  numstat="$(git diff --numstat "$merge_base" "$head_sha" -- . "${exclude_specs[@]}")"
 else
-  numstat="$(git diff --numstat "$base_sha" "$head_sha" -- .)"
+  numstat="$(git diff --numstat "$merge_base" "$head_sha" -- .)"
 fi
 
 total=0

--- a/tests/check-pr-lines.bats
+++ b/tests/check-pr-lines.bats
@@ -67,3 +67,27 @@ teardown() {
 
   rm -f "$exclude_file"
 }
+
+@test "counts changes from the merge base when the base branch has moved" {
+  git -C "$repo" switch -qc pr-branch "$base_sha"
+  printf 'branch change\n' > "$repo/feature.txt"
+  git -C "$repo" add feature.txt
+  git -C "$repo" commit -qm "branch change"
+  pr_head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" switch -qc base-branch "$base_sha"
+  printf 'unrelated base change\n' > "$repo/unrelated.txt"
+  git -C "$repo" add unrelated.txt
+  git -C "$repo" commit -qm "unrelated base change"
+  moved_base_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  cd "$repo" || return 1
+
+  run bash "$script" \
+    --threshold 1 \
+    --base "$moved_base_sha" \
+    --head "$pr_head_sha"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR changes 1 lines"* ]]
+}


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [x] Updated `check-pr-lines` to count changes from the merge base instead of the moving base branch head
- [x] Added a Bats regression test for PR branches where the base branch has moved after the branch diverged

### Why?

I am doing this because:

- `check-pr-lines` can currently count unrelated changes that landed on `main` after a PR branch was created
- docs exclusions were already configured correctly, but the action was diffing the wrong commit range
- using the merge base keeps the threshold focused on the PR branch's actual changes
