### PR TITLE
BAU: Clean stale branches

### DIFF
--- a/.github/workflows/close-stale-pull-requests-reusable.yml
+++ b/.github/workflows/close-stale-pull-requests-reusable.yml
@@ -20,7 +20,7 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -80,10 +80,91 @@ jobs:
             if [[ "${DRY_RUN}" == "true" ]]; then
               echo "[DRY RUN] Would close PR #${number} (last updated ${updated_at})"
             else
-              gh pr close "${number}" --repo "${REPO}" --comment "${comment}"
+              gh pr close "${number}" --repo "${REPO}" --comment "${comment}" --delete-branch
               echo "Closed PR #${number}"
               closed=$((closed + 1))
             fi
           done
 
           echo "Summary: closed=${closed}, skipped_keep=${skipped_keep}, skipped_fresh=${skipped_fresh}"
+      - name: Clean stale branches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          STALE_DAYS: ${{ inputs.stale_days }}
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          stale_seconds=$((STALE_DAYS * 86400))
+          now=$(date -u +%s)
+          deleted=0
+          skipped_default=0
+          skipped_protected=0
+          skipped_open_pr=0
+          skipped_fresh=0
+
+          echo "Repository: ${REPO}"
+          echo "Branch stale threshold: ${STALE_DAYS} days"
+          echo "Dry run: ${DRY_RUN}"
+
+          default_branch=$(gh repo view "${REPO}" --json defaultBranchRef --jq '.defaultBranchRef.name')
+
+          declare -A open_pr_branches=()
+          while IFS= read -r branch_name; do
+            [[ -n "${branch_name}" ]] || continue
+            open_pr_branches["${branch_name}"]=1
+          done < <(gh pr list --repo "${REPO}" --state open --json headRefName --limit 500 --jq '.[].headRefName')
+
+          mapfile -t branches < <(gh api "repos/${REPO}/branches" --paginate --jq '.[] | @json')
+
+          if [[ ${#branches[@]} -eq 0 ]]; then
+            echo "No branches."
+            exit 0
+          fi
+
+          for branch_json in "${branches[@]}"; do
+            name=$(jq -r '.name' <<<"${branch_json}")
+            protected=$(jq -r '.protected' <<<"${branch_json}")
+            sha=$(jq -r '.commit.sha' <<<"${branch_json}")
+
+            if [[ "${name}" == "${default_branch}" ]]; then
+              echo "Skipping branch ${name} (default branch)"
+              skipped_default=$((skipped_default + 1))
+              continue
+            fi
+
+            if [[ "${protected}" == "true" ]]; then
+              echo "Skipping branch ${name} (protected)"
+              skipped_protected=$((skipped_protected + 1))
+              continue
+            fi
+
+            if [[ -n "${open_pr_branches[${name}]+x}" ]]; then
+              echo "Skipping branch ${name} (open pull request)"
+              skipped_open_pr=$((skipped_open_pr + 1))
+              continue
+            fi
+
+            commit_json=$(gh api "repos/${REPO}/commits/${sha}")
+            committed_at=$(jq -r '.commit.committer.date // .commit.author.date' <<<"${commit_json}")
+            committed_epoch=$(date -u -d "${committed_at}" +%s)
+            age=$((now - committed_epoch))
+
+            if (( age < stale_seconds )); then
+              skipped_fresh=$((skipped_fresh + 1))
+              continue
+            fi
+
+            age_days=$((age / 86400))
+
+            if [[ "${DRY_RUN}" == "true" ]]; then
+              echo "[DRY RUN] Would delete branch ${name} (last commit ${committed_at}, ${age_days} days old)"
+            else
+              gh api --method DELETE "repos/${REPO}/git/refs/heads/${name}"
+              echo "Deleted branch ${name}"
+              deleted=$((deleted + 1))
+            fi
+          done
+
+          echo "Summary: deleted=${deleted}, skipped_default=${skipped_default}, skipped_protected=${skipped_protected}, skipped_open_pr=${skipped_open_pr}, skipped_fresh=${skipped_fresh}"

--- a/tests/close-stale-pull-requests-reusable.bats
+++ b/tests/close-stale-pull-requests-reusable.bats
@@ -11,7 +11,47 @@ setup() {
 set -euo pipefail
 
 if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  if [[ "$*" == *"headRefName"* ]]; then
+    printf '%s\n' 'open-pr-branch'
+    exit 0
+  fi
+
   printf '%s\n' '[{"number":10,"updatedAt":"2026-05-01T12:00:00Z","labels":[]},{"number":11,"updatedAt":"2026-05-01T12:00:00Z","labels":[{"name":"keep"}]}]'
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "close" ]]; then
+  printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/gh-close-commands.txt"
+  exit 0
+fi
+
+if [[ "$1" == "repo" && "$2" == "view" ]]; then
+  printf '%s\n' 'main'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/branches" ]]; then
+  printf '%s\n' \
+    '{"name":"main","protected":false,"commit":{"sha":"sha-main"}}' \
+    '{"name":"protected-branch","protected":true,"commit":{"sha":"sha-protected"}}' \
+    '{"name":"open-pr-branch","protected":false,"commit":{"sha":"sha-open"}}' \
+    '{"name":"fresh-branch","protected":false,"commit":{"sha":"sha-fresh"}}' \
+    '{"name":"stale-branch","protected":false,"commit":{"sha":"sha-stale"}}'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/commits/sha-fresh" ]]; then
+  printf '%s\n' '{"commit":{"committer":{"date":"2026-06-03T12:00:00Z"}}}'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/commits/sha-stale" ]]; then
+  printf '%s\n' '{"commit":{"committer":{"date":"2026-05-01T12:00:00Z"}}}'
+  exit 0
+fi
+
+if [[ "$1" == "api" && "$2" == "--method" && "$3" == "DELETE" ]]; then
+  printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/gh-delete-commands.txt"
   exit 0
 fi
 
@@ -30,6 +70,11 @@ extract_close_stale_script() {
     "$repo_root/.github/workflows/close-stale-pull-requests-reusable.yml"
 }
 
+extract_clean_branches_script() {
+  ruby -ryaml -e 'puts YAML.load_file(ARGV.fetch(0)).fetch("jobs").fetch("close-stale").fetch("steps").fetch(1).fetch("run")' \
+    "$repo_root/.github/workflows/close-stale-pull-requests-reusable.yml"
+}
+
 @test "close stale workflow iterates over pull requests returned by gh" {
   script="$tmpdir/close-stale.sh"
   extract_close_stale_script > "$script"
@@ -45,4 +90,49 @@ extract_close_stale_script() {
   assert_contains "$output" "[DRY RUN] Would close PR #10"
   assert_contains "$output" "Skipping PR #11 (label: keep)"
   assert_contains "$output" "Summary: closed=0, skipped_keep=1, skipped_fresh=0"
+}
+
+@test "close stale workflow deletes the branch when closing a pull request" {
+  script="$tmpdir/close-stale.sh"
+  extract_close_stale_script > "$script"
+
+  run env \
+    TEST_CAPTURE_DIR="$tmpdir" \
+    REPO="trade-tariff/example" \
+    STALE_DAYS="14" \
+    KEEP_LABEL="keep" \
+    DRY_RUN="false" \
+    bash "$script"
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Closed PR #10"
+  assert_contains "$output" "Summary: closed=1, skipped_keep=1, skipped_fresh=0"
+  close_commands="$(cat "$tmpdir/gh-close-commands.txt")"
+  assert_contains "$close_commands" "pr close 10 --repo trade-tariff/example"
+  assert_contains "$close_commands" "--delete-branch"
+}
+
+@test "clean branches workflow deletes stale branches without open pull requests" {
+  script="$tmpdir/clean-branches.sh"
+  extract_clean_branches_script > "$script"
+
+  run env \
+    TEST_CAPTURE_DIR="$tmpdir" \
+    REPO="trade-tariff/example" \
+    STALE_DAYS="14" \
+    DRY_RUN="false" \
+    bash "$script"
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Skipping branch main (default branch)"
+  assert_contains "$output" "Skipping branch protected-branch (protected)"
+  assert_contains "$output" "Skipping branch open-pr-branch (open pull request)"
+  assert_contains "$output" "Deleted branch stale-branch"
+  assert_contains "$output" "Summary: deleted=1, skipped_default=1, skipped_protected=1, skipped_open_pr=1, skipped_fresh=1"
+  delete_commands="$(cat "$tmpdir/gh-delete-commands.txt")"
+  assert_contains "$delete_commands" "api --method DELETE repos/trade-tariff/example/git/refs/heads/stale-branch"
+  assert_not_contains "$delete_commands" "main"
+  assert_not_contains "$delete_commands" "protected-branch"
+  assert_not_contains "$delete_commands" "open-pr-branch"
+  assert_not_contains "$delete_commands" "fresh-branch"
 }


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Delete PR head branches when stale pull requests are closed
- [x] Add a second reusable workflow step to clean stale unprotected branches with no open pull request
- [x] Skip default branches, protected branches, open PR branches and fresh branches
- [x] Add Bats regression coverage for PR branch deletion and stale branch cleanup

### Why?

Closing stale pull requests only removes branches attached to those PRs. Old pushed branches without an open pull request can still build up, so the reusable workflow now removes stale branch refs directly when they are safe to delete.

### Risk

**Risk level:** 🟢

**Reason for rating:** Scheduled GitHub Actions maintenance workflow change with dry-run support, explicit branch exclusions, and regression coverage.