### PR TITLE
HMRC-2247: Investigate auto-merging low-risk PRs with a successful Co…

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -1,7 +1,8 @@
 name: Auto-merge low-risk PR
 description: >-
-  Enable GitHub auto-merge when a PR has the configured label, Copilot has
-  reviewed it, and all Copilot review threads are resolved.
+  Enable or disable GitHub auto-merge for low-risk PRs. Requests Copilot review
+  when needed, then enables auto-merge once Copilot has reviewed and all Copilot
+  threads are resolved.
 
 inputs:
   pr-number:
@@ -15,6 +16,18 @@ inputs:
     description: 'merge, squash, or rebase.'
     required: false
     default: merge
+  pull-request-event-action:
+    description: >-
+      github.event.action from the caller workflow (e.g. labeled, unlabeled).
+      Used to disable auto-merge when the label is removed.
+    required: false
+    default: ''
+  pull-request-event-label:
+    description: >-
+      github.event.label.name from the caller workflow when action is labeled
+      or unlabeled.
+    required: false
+    default: ''
   github-token:
     description: Token used to call the GitHub API.
     required: false
@@ -29,8 +42,45 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
         AUTO_MERGE_LABEL: ${{ inputs.label }}
         AUTO_MERGE_METHOD: ${{ inputs.merge-method }}
+        PR_EVENT_ACTION: ${{ inputs.pull-request-event-action }}
+        PR_EVENT_LABEL: ${{ inputs.pull-request-event-label }}
       run: |
         set -euo pipefail
+
+        repo="${{ github.repository }}"
+
+        disable_auto_merge() {
+          if gh pr view "$PR_NUMBER" \
+            --repo "$repo" \
+            --json autoMergeRequest \
+            -q '.autoMergeRequest != null'; then
+            echo "Disabling auto-merge for PR #$PR_NUMBER"
+            gh pr merge "$PR_NUMBER" --repo "$repo" --disable-auto
+          else
+            echo "Auto-merge is not enabled for PR #$PR_NUMBER; nothing to disable."
+          fi
+        }
+
+        request_copilot_review() {
+          pending="$(gh pr view "$PR_NUMBER" \
+            --repo "$repo" \
+            --json reviewRequests \
+            -q '[.reviewRequests[]? | select(.login | test("copilot"; "i"))] | length')"
+
+          if [[ "${pending:-0}" -gt 0 ]]; then
+            echo "Copilot review already requested on PR #$PR_NUMBER."
+            return 0
+          fi
+
+          echo "Requesting Copilot code review for PR #$PR_NUMBER"
+          gh pr edit "$PR_NUMBER" --repo "$repo" --add-reviewer copilot
+        }
+
+        # Label removed — turn off auto-merge.
+        if [[ "$PR_EVENT_ACTION" == "unlabeled" && "$PR_EVENT_LABEL" == "$AUTO_MERGE_LABEL" ]]; then
+          disable_auto_merge
+          exit 0
+        fi
 
         gate_script="${{ github.action_path }}/check-copilot-review-gate.sh"
         if [[ ! -f "$gate_script" ]]; then
@@ -48,7 +98,7 @@ runs:
         esac
 
         labels="$(gh pr view "$PR_NUMBER" \
-          --repo "${{ github.repository }}" \
+          --repo "$repo" \
           --json labels \
           -q '.labels[].name')"
 
@@ -57,15 +107,24 @@ runs:
           exit 0
         fi
 
-        if ! "$gate_script" \
-          --repo "${{ github.repository }}" \
-          --pr "$PR_NUMBER"; then
+        set +e
+        "$gate_script" --repo "$repo" --pr "$PR_NUMBER"
+        gate_status=$?
+        set -e
+
+        if [[ "$gate_status" -eq 2 ]]; then
+          request_copilot_review
+          echo "Waiting for Copilot to review PR #$PR_NUMBER; auto-merge will be retried on the next workflow run."
+          exit 0
+        fi
+
+        if [[ "$gate_status" -ne 0 ]]; then
           echo "Copilot review requirements not met for PR #$PR_NUMBER; skipping auto-merge."
           exit 0
         fi
 
         if gh pr view "$PR_NUMBER" \
-          --repo "${{ github.repository }}" \
+          --repo "$repo" \
           --json autoMergeRequest \
           -q '.autoMergeRequest != null'; then
           echo "Auto-merge already enabled for PR #$PR_NUMBER."
@@ -74,6 +133,6 @@ runs:
 
         echo "Enabling auto-merge (${AUTO_MERGE_METHOD}) for PR #$PR_NUMBER"
         gh pr merge "$PR_NUMBER" \
-          --repo "${{ github.repository }}" \
+          --repo "$repo" \
           "--${AUTO_MERGE_METHOD}" \
           --auto

--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -7,7 +7,9 @@ usage() {
 Usage: check-copilot-review-gate.sh --repo <owner/name> --pr <number>
 
 Exits 0 when Copilot has submitted at least one PR review and every Copilot
-inline review thread is resolved. Exits 1 with a message on stderr otherwise.
+inline review thread is resolved.
+Exits 2 when Copilot has not reviewed yet.
+Exits 1 when Copilot review threads are still unresolved.
 EOF
 }
 
@@ -77,8 +79,8 @@ copilot_review_count="$(gh pr view "$pr" \
   -q "$COPILOT_REVIEW_JQ")"
 
 if [[ "${copilot_review_count:-0}" -lt 1 ]]; then
-  echo "PR #$pr has not been reviewed by Copilot yet. Request a review from Copilot before auto-merge." >&2
-  exit 1
+  echo "PR #$pr has not been reviewed by Copilot yet." >&2
+  exit 2
 fi
 
 threads_file="$(mktemp)"

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -71,3 +71,5 @@ jobs:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}
           merge-method: ${{ inputs.merge-method }}
+          pull-request-event-action: ${{ github.event.action }}
+          pull-request-event-label: ${{ github.event.label.name }}


### PR DESCRIPTION
### Jira link

[HMRC-2247](https://transformuk.atlassian.net/browse/HMRC-2247)

### What?

I have added/removed/altered:

- [ ] Added a request copilot to review pr
- [ ] Disbale auto merge on remove low-risk lable


### Why?

I am doing this because:

- Low-risk PRs (those without the high-risk or medium-risk label, passing all CI checks) often sit waiting for a human reviewer despite being straightforward changes. Enabling auto-merge for these PRs — gated on a successful Copilot review — could significantly reduce cycle time and free up reviewer bandwidth for more complex work.

### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
