### PR TITLE
HMRC-2247: Investigate auto-merging low-risk PRs with a successful copilot review

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -8,6 +8,9 @@ inputs:
   pr-number:
     description: Pull request number in the caller repository.
     required: true
+  github-token:
+    description: Token used to call the GitHub API.
+    required: true
   label:
     description: PR label that enables auto-merge.
     required: false
@@ -28,10 +31,6 @@ inputs:
       or unlabeled.
     required: false
     default: ''
-  github-token:
-    description: Token used to call the GitHub API.
-    required: false
-    default: ${{ github.token }}
 
 runs:
   using: composite
@@ -122,6 +121,10 @@ runs:
           echo "Copilot review requirements not met for PR #$PR_NUMBER; skipping auto-merge."
           exit 0
         fi
+        
+        gh pr review "$PR_NUMBER" \
+          --repo "$repo" \
+          --approve
 
         if gh pr view "$PR_NUMBER" \
           --repo "$repo" \

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Auto-merge when requirements are met
         if: steps.pr.outputs.number != ''
-        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@HMRC-2247-2
+        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@main
         with:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: merge
 
+    secrets:
+      github-token:
+        description: Token used to call the GitHub API.
+        required: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -66,10 +71,11 @@ jobs:
 
       - name: Auto-merge when requirements are met
         if: steps.pr.outputs.number != ''
-        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@main
+        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@HMRC-2247-2
         with:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}
           merge-method: ${{ inputs.merge-method }}
+          github-token: ${{ secrets.github-token }}
           pull-request-event-action: ${{ github.event.action }}
           pull-request-event-label: ${{ github.event.label.name }}


### PR DESCRIPTION
### Jira link

[HMRC-2247](https://transformuk.atlassian.net/browse/HMRC-2247)

### What?

I have added/removed/altered:

- [ ] Added a pr approve request before turning auto-merge on


### Why?

I am doing this because:

- Low-risk PRs (those without the high-risk or medium-risk label, passing all CI checks) often sit waiting for a human reviewer despite being straightforward changes. Enabling auto-merge for these PRs — gated on a successful Copilot review — could significantly reduce cycle time and free up reviewer bandwidth for more complex work.

### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
