### PR TITLE
HMRC-2247: Investigate auto-merging low-risk PRs with a successful copilot review

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -54,7 +54,10 @@ runs:
             --json autoMergeRequest \
             -q '.autoMergeRequest != null'; then
             echo "Disabling auto-merge for PR #$PR_NUMBER"
-            gh pr merge "$PR_NUMBER" --repo "$repo" --disable-auto
+            gh pr merge "$PR_NUMBER" \
+              --repo "$repo" \
+              "--${AUTO_MERGE_METHOD}" \
+              --disable-auto
           else
             echo "Auto-merge is not enabled for PR #$PR_NUMBER; nothing to disable."
           fi

--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -49,10 +49,14 @@ runs:
         repo="${{ github.repository }}"
 
         disable_auto_merge() {
-          if gh pr view "$PR_NUMBER" \
-            --repo "$repo" \
-            --json autoMergeRequest \
-            -q '.autoMergeRequest != null'; then
+          auto_merge_enabled=$(
+            gh pr view "$PR_NUMBER" \
+              --repo "$repo" \
+              --json autoMergeRequest \
+              -q '.autoMergeRequest != null'
+          )
+        
+          if [[ "$auto_merge_enabled" == "true" ]]; then
             echo "Disabling auto-merge for PR #$PR_NUMBER"
             gh pr merge "$PR_NUMBER" \
               --repo "$repo" \
@@ -129,10 +133,14 @@ runs:
           --repo "$repo" \
           --approve
 
-        if gh pr view "$PR_NUMBER" \
-          --repo "$repo" \
-          --json autoMergeRequest \
-          -q '.autoMergeRequest != null'; then
+        auto_merge_enabled=$(
+          gh pr view "$PR_NUMBER" \
+            --repo "$repo" \
+            --json autoMergeRequest \
+            -q '.autoMergeRequest != null'
+        )
+          
+        if [[ "$auto_merge_enabled" == "true" ]]; then
           echo "Auto-merge already enabled for PR #$PR_NUMBER."
           exit 0
         fi

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Auto-merge when requirements are met
         if: steps.pr.outputs.number != ''
-        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@main
+        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@HMRC-2247-2
         with:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Auto-merge when requirements are met
         if: steps.pr.outputs.number != ''
-        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@HMRC-2247-2
+        uses: trade-tariff/trade-tariff-tools/.github/actions/auto-merge-low-risk@main
         with:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}


### PR DESCRIPTION
### Jira link

[HMRC-2247](https://transformuk.atlassian.net/browse/HMRC-2247)

### What?

I have added/removed/altered:

- [ ] Added a pr approve request before turning auto-merge on


### Why?

I am doing this because:

- Low-risk PRs (those without the high-risk or medium-risk label, passing all CI checks) often sit waiting for a human reviewer despite being straightforward changes. Enabling auto-merge for these PRs — gated on a successful Copilot review — could significantly reduce cycle time and free up reviewer bandwidth for more complex work.

### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
