### PR TITLE
BAU: Preserve account-suffixed job families

### DIFF
--- a/bin/cleanup-ecs-families
+++ b/bin/cleanup-ecs-families
@@ -46,7 +46,7 @@ family_is_preserved() {
     local family="$1"
 
     for suffix in "${PRESERVE_FAMILY_SUFFIXES[@]}"; do
-        if [[ "$family" == *"$suffix" ]]; then
+        if [[ "$family" == *"$suffix" || "$family" == *"$suffix"-* ]]; then
             return 0
         fi
     done

--- a/tests/cleanup-ecs-families.bats
+++ b/tests/cleanup-ecs-families.bats
@@ -73,6 +73,17 @@ teardown() {
   assert_not_contains "$output" " - admin-job"
 }
 
+@test "report preserves account-suffixed job task families" {
+  run env TEST_FAMILIES="admin-job-123456789012 dev-hub-job-123456789012 backend-job-123456789012 identity-job-123456789012 stale-worker" "$repo_root/bin/cleanup-ecs-families" report
+
+  [ "$status" -eq 0 ]
+  assert_not_contains "$output" " - admin-job-123456789012"
+  assert_not_contains "$output" " - dev-hub-job-123456789012"
+  assert_not_contains "$output" " - backend-job-123456789012"
+  assert_not_contains "$output" " - identity-job-123456789012"
+  assert_contains "$output" " - stale-worker"
+}
+
 @test "deregister ignores prefix results from other families" {
   capture_dir="$tmpdir/capture"
   mkdir -p "$capture_dir"


### PR DESCRIPTION
### Jira link

N/A - BAU

### What?

- [x] Preserve ECS task definition families that end in `-job`
- [x] Preserve account-suffixed ECS job task definition families such as `backend-job-382373577178`
- [x] Add a regression test covering `admin-job-*`, `dev-hub-job-*`, `backend-job-*`, and `identity-job-*`

### Why?

The nightly ECS task family cleanup job was treating account-suffixed job families as unused because the preserve check only matched names that literally ended with `-job`.

Backend deploys register fresh `backend-job-<account_id>` task definitions, and the backend Terraform wires the scheduled backup EventBridge target to the current backend job task definition ARN. The cleanup job can still break the next scheduled run if it deregisters the active account-suffixed job family revision that EventBridge is currently targeting.

This keeps the existing exact-family deregistration safeguard and tightens the preserve pattern to cover both `*-job` and `*-job-*` family names.

### Risk

**Risk level:** 🟢

**Reason for rating:** Narrow shell-script predicate change with regression coverage. It only makes cleanup preserve scheduled job task families that should not be removed.