### PR TITLE
HMRC-2247: Investigate auto-merging low-risk PRs with a successful Copilot review - enable workflow-run trigger

### DIFF
--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -43,10 +43,6 @@ jobs:
               echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
               ;;
             workflow_run)
-              if [[ "${{ github.event.workflow_run.event }}" != "pull_request" ]]; then
-                echo "number=" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
               if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
                 echo "number=" >> "$GITHUB_OUTPUT"
                 exit 0


### PR DESCRIPTION

### Jira link

[HMRC-2247](https://transformuk.atlassian.net/browse/HMRC-2247)

### What?

I have added/removed/altered:

- [ ] Enabled workflow-run trigger

### Why?

I am doing this because:

- Low-risk PRs (those without the high-risk or medium-risk label, passing all CI checks) often sit waiting for a human reviewer despite being straightforward changes. Enabling auto-merge for these PRs — gated on a successful Copilot review — could significantly reduce cycle time and free up reviewer bandwidth for more complex work.

### Have you? (optional)

- [ ] Clearly documented/self-documented any scripts I've added
- [ ] Respected people's right not to receive lots of noisy messages
