### PR TITLE
Silently exit when GraphQL is not accessible by PAT

### DIFF
--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -111,7 +111,13 @@ while true; do
       -f owner="$owner" \
       -f repo="$name" \
       -F pr="$pr" \
-      -f cursor="$cursor")"
+      -f cursor="$cursor" 2>&1)" || {
+      if grep -qi "resource not accessible by personal access token" <<< "$response"; then
+        exit 0
+      fi
+      echo "$response" >&2
+      exit 1
+    }
   else
     response="$(gh api graphql \
       -f query='query($owner: String!, $repo: String!, $pr: Int!) {
@@ -134,7 +140,13 @@ while true; do
       }' \
       -f owner="$owner" \
       -f repo="$name" \
-      -F pr="$pr")"
+      -F pr="$pr" 2>&1)" || {
+      if grep -qi "resource not accessible by personal access token" <<< "$response"; then
+        exit 0
+      fi
+      echo "$response" >&2
+      exit 1
+    }
   fi
 
   jq -c '.data.repository.pullRequest.reviewThreads.nodes[]?' <<< "$response" >> "$threads_file"


### PR DESCRIPTION
## Summary

- Catches `Resource not accessible by personal access token` errors from `gh api graphql` in `check-copilot-review-gate.sh`
- Exits 0 silently rather than failing the auto-merge workflow when the PAT lacks GraphQL access
- Any other GraphQL errors still surface normally

## Test Plan

- [ ] Trigger the auto-merge workflow with a PAT that lacks GraphQL access — confirm workflow passes cleanly with no error output
- [ ] Confirm normal GraphQL errors still surface as failures