### PR TITLE
Refactor ECS task definition inventory

### DIFF
--- a/bin/cleanup-ecs-families
+++ b/bin/cleanup-ecs-families
@@ -6,6 +6,10 @@ set -o nounset
 set -o pipefail
 set -o noclobber
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../scripts/ecs-task-definition-inventory.sh
+source "$repo_root/scripts/ecs-task-definition-inventory.sh"
+
 declare -A CLUSTERS
 declare -A CLUSTERS=(
     ["development"]="trade-tariff-cluster-development"
@@ -37,28 +41,6 @@ while [[ "$#" -gt 0 ]]; do
     esac
     shift
 done
-
-declare -a PRESERVE_FAMILY_SUFFIXES=(
-    "-job"
-)
-
-family_is_preserved() {
-    local family="$1"
-
-    for suffix in "${PRESERVE_FAMILY_SUFFIXES[@]}"; do
-        if [[ "$family" == *"$suffix" || "$family" == *"$suffix"-* ]]; then
-            return 0
-        fi
-    done
-
-    return 1
-}
-
-task_definition_family() {
-    local task_definition_arn="$1"
-    local family_revision="${task_definition_arn##*/}"
-    echo "${family_revision%:*}"
-}
 
 declare ENVIRONMENT="${ENVIRONMENT:-development}"
 CLUSTER="${CLUSTERS[$ENVIRONMENT]}"
@@ -103,7 +85,7 @@ if [[ "$MODE" == "report" ]]; then
 fi
 
 echo "🔍 Fetching all ACTIVE Task Definition families..."
-ALL_FAMILIES=($(aws ecs list-task-definition-families --status ACTIVE --query 'families[]' --output text))
+ALL_FAMILIES=($(list_active_task_definition_families))
 
 CANDIDATES=()
 
@@ -153,13 +135,9 @@ elif [[ "$MODE" == "deregister" ]]; then
     echo "DEREGISTERING: Starting cleanup of ${#CANDIDATES[@]} families..."
 
     for fam in "${CANDIDATES[@]}"; do
-        revisions=($(aws ecs list-task-definitions --family-prefix "$fam" --status ACTIVE --query 'taskDefinitionArns[]' --output text))
+        revisions=($(list_exact_active_task_definition_revisions "$fam"))
         count=0
         for revision_arn in "${revisions[@]}"; do
-            if [[ "$(task_definition_family "$revision_arn")" != "$fam" ]]; then
-                continue
-            fi
-
             echo "   - Deregistering: $revision_arn"
             AWS_MAX_ATTEMPTS=10 aws ecs deregister-task-definition --task-definition "$revision_arn" > /dev/null
             (( count+=1 ))

--- a/bin/rotate-revisions
+++ b/bin/rotate-revisions
@@ -6,6 +6,10 @@ set -o nounset
 set -o pipefail
 set -o noclobber
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../scripts/ecs-task-definition-inventory.sh
+source "$repo_root/scripts/ecs-task-definition-inventory.sh"
+
 USED_ARNS_FILE=$(mktemp)
 
 cleanup() {
@@ -13,12 +17,6 @@ cleanup() {
 }
 
 trap cleanup EXIT
-
-task_definition_family() {
-    local task_definition_arn="$1"
-    local family_revision="${task_definition_arn##*/}"
-    echo "${family_revision%:*}"
-}
 
 in_use_revisions() {
     echo "Scanning for used Task Definitions..." >&2
@@ -65,13 +63,13 @@ deregister_unused() {
     local keep_latest="$2"
 
     local families
-    families=($(aws ecs list-task-definition-families --status ACTIVE --query 'families[]' --output text))
+    families=($(list_active_task_definition_families))
 
     for family in "${families[@]}"; do
         echo "Processing family: $family"
 
         local revisions
-        revisions=($(aws ecs list-task-definitions --family-prefix "$family" --status ACTIVE --sort DESC --query 'taskDefinitionArns[]' --output text))
+        revisions=($(list_exact_active_task_definition_revisions "$family"))
 
         if [ ${#revisions[@]} -eq 0 ]; then
              echo "  [SKIP] No active revisions found."
@@ -80,10 +78,6 @@ deregister_unused() {
 
         local count=0
         for arn in "${revisions[@]}"; do
-            if [[ "$(task_definition_family "$arn")" != "$family" ]]; then
-                continue
-            fi
-
             set +e  # NOTE: count++ exits with status 1 when count is zero
             ((count++))
             set -e

--- a/scripts/ecs-task-definition-inventory.sh
+++ b/scripts/ecs-task-definition-inventory.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+declare -ga PRESERVE_FAMILY_SUFFIXES=(
+  "-job"
+)
+
+family_is_preserved() {
+  local family="$1"
+
+  for suffix in "${PRESERVE_FAMILY_SUFFIXES[@]}"; do
+    if [[ "$family" == *"$suffix" || "$family" == *"$suffix"-* ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+task_definition_family() {
+  local task_definition_arn="$1"
+  local family_revision="${task_definition_arn##*/}"
+  echo "${family_revision%:*}"
+}
+
+list_active_task_definition_families() {
+  aws ecs list-task-definition-families \
+    --status ACTIVE \
+    --query 'families[]' \
+    --output text
+}
+
+list_exact_active_task_definition_revisions() {
+  local family="$1"
+  local revisions
+
+  revisions=$(aws ecs list-task-definitions \
+    --family-prefix "$family" \
+    --status ACTIVE \
+    --query 'taskDefinitionArns[]' \
+    --output text)
+
+  for revision_arn in $revisions; do
+    if [[ "$(task_definition_family "$revision_arn")" == "$family" ]]; then
+      echo "$revision_arn"
+    fi
+  done
+}

--- a/tests/ecs-task-definition-inventory.bats
+++ b/tests/ecs-task-definition-inventory.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  source "$repo_root/scripts/ecs-task-definition-inventory.sh"
+}
+
+@test "task_definition_family returns the exact family from an ARN" {
+  run task_definition_family "arn:aws:ecs:eu-west-2:123456789012:task-definition/admin-job:7"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "admin-job" ]
+}
+
+@test "task_definition_family returns the exact family from an account-suffixed ARN" {
+  run task_definition_family "arn:aws:ecs:eu-west-2:123456789012:task-definition/backend-job-123456789012:42"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "backend-job-123456789012" ]
+}
+
+@test "family_is_preserved preserves job families with and without account suffixes" {
+  family_is_preserved "admin-job"
+  family_is_preserved "admin-job-123456789012"
+}
+
+@test "family_is_preserved does not preserve non-job families" {
+  if family_is_preserved "admin"; then
+    fail "admin should not be preserved"
+  fi
+
+  if family_is_preserved "admin-worker"; then
+    fail "admin-worker should not be preserved"
+  fi
+}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added `scripts/ecs-task-definition-inventory.sh` for shared ECS task definition family/revision helpers
- [x] Updated `bin/cleanup-ecs-families` and `bin/rotate-revisions` to use the shared helper while keeping their command interfaces unchanged
- [x] Added direct Bats coverage for exact family parsing and preserved job-family rules

### Why?

I am doing this because:

- Both cleanup commands had duplicated task-definition parsing and exact-family filtering rules.
- The destructive deregistration paths should share one tested implementation for prefix-collision safety.
- The checked-out sibling repos do not directly consume these scripts, so preserving the command interfaces in this repo is the compatibility target.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages