### PR TITLE
Refactor tariff environment configuration

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -1,0 +1,98 @@
+name: 'Configure Tariff environment'
+description: 'Derives shared AWS, ECS, and notification settings for a Tariff environment.'
+
+inputs:
+  environment:
+    description: 'The environment to configure: development, staging, or production.'
+    required: true
+  app-name:
+    description: 'Optional deployed app name, for example tariff-backend or tariff-identity.'
+    required: false
+    default: ''
+  service-names:
+    description: 'Optional space-separated ECS service names for service control workflows.'
+    required: false
+    default: ''
+  region:
+    description: 'AWS region.'
+    required: false
+    default: 'eu-west-2'
+
+outputs:
+  account-id:
+    description: 'AWS account ID for the environment.'
+    value: ${{ steps.configure.outputs.account-id }}
+  cleanup-role-arn:
+    description: 'IAM role ARN for ECS cleanup operations.'
+    value: ${{ steps.configure.outputs.cleanup-role-arn }}
+  cluster:
+    description: 'ECS cluster name for the environment.'
+    value: ${{ steps.configure.outputs.cluster }}
+  deploy-role-arn:
+    description: 'IAM role ARN for ECS deployment operations.'
+    value: ${{ steps.configure.outputs.deploy-role-arn }}
+  ecr-url:
+    description: 'Production ECR URL for the supplied app name.'
+    value: ${{ steps.configure.outputs.ecr-url }}
+  log-group:
+    description: 'CloudWatch platform log group.'
+    value: ${{ steps.configure.outputs.log-group }}
+  security-group-name:
+    description: 'ECS security group name.'
+    value: ${{ steps.configure.outputs.security-group-name }}
+  slack-channel:
+    description: 'Slack deployment notification channel.'
+    value: ${{ steps.configure.outputs.slack-channel }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: configure
+      shell: bash
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        APP_NAME: ${{ inputs.app-name }}
+        SERVICE_NAMES: ${{ inputs.service-names }}
+        REGION: ${{ inputs.region }}
+      run: |
+        case "$ENVIRONMENT" in
+          development)
+            ACCOUNT_ID="844815912454"
+            SLACK_CHANNEL="deployments"
+            ;;
+          staging)
+            ACCOUNT_ID="451934005581"
+            SLACK_CHANNEL="deployments"
+            ;;
+          production)
+            ACCOUNT_ID="382373577178"
+            SLACK_CHANNEL="production-deployments"
+            ;;
+          *)
+            echo "Invalid environment: $ENVIRONMENT"
+            exit 1
+            ;;
+        esac
+
+        DEPLOY_ROLE_NAME="GithubActions-ECS-Deployments-Role"
+        if [ "$APP_NAME" = "tariff-identity" ]; then
+          DEPLOY_ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
+        fi
+
+        for SERVICE_NAME in $SERVICE_NAMES; do
+          if [ "$SERVICE_NAME" = "identity" ]; then
+            DEPLOY_ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
+            break
+          fi
+        done
+
+        {
+          echo "account-id=${ACCOUNT_ID}"
+          echo "cleanup-role-arn=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-ECS-Task-Cleanup-Role"
+          echo "cluster=trade-tariff-cluster-${ENVIRONMENT}"
+          echo "deploy-role-arn=arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOY_ROLE_NAME}"
+          echo "ecr-url=382373577178.dkr.ecr.${REGION}.amazonaws.com/${APP_NAME}-production"
+          echo "log-group=platform-logs-${ENVIRONMENT}"
+          echo "security-group-name=trade-tariff-ecs-security-group-${ENVIRONMENT}"
+          echo "slack-channel=${SLACK_CHANNEL}"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/start-services/action.yml
+++ b/.github/actions/start-services/action.yml
@@ -18,39 +18,17 @@ runs:
   steps:
     - uses: actions/checkout@v6
     - id: config
-      run: |
-        case "${{ inputs.environment }}" in
-          development)
-            ACCOUNT_ID="844815912454"
-            ;;
-          staging)
-            ACCOUNT_ID="451934005581"
-            ;;
-          production)
-            ACCOUNT_ID="382373577178"
-            ;;
-          *)
-            echo "Invalid environment: ${{ inputs.environment }}"
-            exit 1
-            ;;
-        esac
-
-        ROLE_NAME="GithubActions-ECS-Deployments-Role"
-        for SERVICE_NAME in ${{ inputs.service-names }}; do
-          if [ "$SERVICE_NAME" = "identity" ]; then
-            ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
-            break
-          fi
-        done
-
-        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" >> "$GITHUB_OUTPUT"
-      shell: bash
+      uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+      with:
+        environment: ${{ inputs.environment }}
+        region: ${{ inputs.region }}
+        service-names: ${{ inputs.service-names }}
     - uses: aws-actions/configure-aws-credentials@v6
       with:
-        role-to-assume: ${{ steps.config.outputs.role_to_assume }}
+        role-to-assume: ${{ steps.config.outputs.deploy-role-arn }}
         aws-region: ${{ inputs.region }}
     - run: |
-        CLUSTER="trade-tariff-cluster-${{ inputs.environment }}"
+        CLUSTER="${{ steps.config.outputs.cluster }}"
         REGION="${{ inputs.region }}"
         DESIRED_COUNT="${{ inputs.desired_count }}"
 

--- a/.github/actions/stop-services/action.yml
+++ b/.github/actions/stop-services/action.yml
@@ -15,39 +15,17 @@ runs:
   steps:
     - uses: actions/checkout@v6
     - id: config
-      run: |
-        case "${{ inputs.environment }}" in
-          development)
-            ACCOUNT_ID="844815912454"
-            ;;
-          staging)
-            ACCOUNT_ID="451934005581"
-            ;;
-          production)
-            ACCOUNT_ID="382373577178"
-            ;;
-          *)
-            echo "Invalid environment: ${{ inputs.environment }}"
-            exit 1
-            ;;
-        esac
-
-        ROLE_NAME="GithubActions-ECS-Deployments-Role"
-        for SERVICE_NAME in ${{ inputs.service-names }}; do
-          if [ "$SERVICE_NAME" = "identity" ]; then
-            ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
-            break
-          fi
-        done
-
-        echo "role_to_assume=arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}" >> "$GITHUB_OUTPUT"
-      shell: bash
+      uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+      with:
+        environment: ${{ inputs.environment }}
+        region: ${{ inputs.region }}
+        service-names: ${{ inputs.service-names }}
     - uses: aws-actions/configure-aws-credentials@v6
       with:
-        role-to-assume: ${{ steps.config.outputs.role_to_assume }}
+        role-to-assume: ${{ steps.config.outputs.deploy-role-arn }}
         aws-region: ${{ inputs.region }}
     - run: |
-        CLUSTER="trade-tariff-cluster-${{ inputs.environment }}"
+        CLUSTER="${{ steps.config.outputs.cluster }}"
         REGION="${{ inputs.region }}"
 
         SUCCEEDED=()

--- a/.github/workflows/cleanup-unused-task-families.yml
+++ b/.github/workflows/cleanup-unused-task-families.yml
@@ -38,10 +38,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: development
+
       - name: Configure AWS credentials for development
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::844815912454:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Cleanup unused task families in development
@@ -63,10 +68,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: staging
+
       - name: Configure AWS credentials for staging
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::451934005581:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Cleanup unused task families in staging
@@ -88,10 +98,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: production
+
       - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::382373577178:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Cleanup unused task families in production

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -97,39 +97,19 @@ jobs:
           repository: ${{ steps.actual-ref.outputs.actual_repo }}
           ref: ${{ steps.actual-ref.outputs.actual_ref }}
 
+      - id: environment-config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          app-name: ${{ inputs.app-name }}
+          environment: ${{ inputs.environment }}
+
       - id: config
         run: |
-          case "${{ inputs.environment }}" in
-            development)
-              ACCOUNT_ID="844815912454"
-              SLACK_CHANNEL=deployments
-              ;;
-            staging)
-              ACCOUNT_ID="451934005581"
-              SLACK_CHANNEL=deployments
-              ;;
-            production)
-              ACCOUNT_ID="382373577178"
-              SLACK_CHANNEL=production-deployments
-              ;;
-            *)
-              echo "Invalid environment: ${{ inputs.environment }}"
-              exit 1
-              ;;
-          esac
-
-
-          if [ "${{ inputs.app-name }}" = "tariff-identity" ]; then
-            DEPLOY_ROLE_NAME="GithubActions-Identity-ECS-Deployments-Role"
-          else
-            DEPLOY_ROLE_NAME="GithubActions-ECS-Deployments-Role"
-          fi
-
           {
-            echo "ecr_url=382373577178.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.app-name }}-production"
-            echo "iam_role_arn=arn:aws:iam::${ACCOUNT_ID}:role/${DEPLOY_ROLE_NAME}"
+            echo "ecr_url=${{ steps.environment-config.outputs.ecr-url }}"
+            echo "iam_role_arn=${{ steps.environment-config.outputs.deploy-role-arn }}"
             echo "ruby_version=$(cat .ruby-version)"
-            echo "slack_channel=${SLACK_CHANNEL}"
+            echo "slack_channel=${{ steps.environment-config.outputs.slack-channel }}"
             echo "docker_tag=$(git rev-parse --short HEAD)"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/rotate-task-definitions.yml
+++ b/.github/workflows/rotate-task-definitions.yml
@@ -31,10 +31,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: development
+
       - name: Configure AWS credentials for development
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::844815912454:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Rotate task definitions in development
@@ -48,10 +53,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: staging
+
       - name: Configure AWS credentials for staging
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::451934005581:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Rotate task definitions in staging
@@ -65,10 +75,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
 
+      - id: config
+        uses: trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main
+        with:
+          environment: production
+
       - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: arn:aws:iam::382373577178:role/GithubActions-ECS-Task-Cleanup-Role
+          role-to-assume: ${{ steps.config.outputs.cleanup-role-arn }}
           aws-region: eu-west-2
 
       - name: Rotate task definitions in production

--- a/tests/configure-environment-action.bats
+++ b/tests/configure-environment-action.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  output_file="$tmpdir/github-output"
+  script="$tmpdir/configure-environment.sh"
+  ruby -ryaml -e 'puts YAML.load_file(ARGV.fetch(0)).fetch("runs").fetch("steps").fetch(0).fetch("run")' \
+    "$repo_root/.github/actions/configure-environment/action.yml" > "$script"
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+run_configure_environment() {
+  GITHUB_OUTPUT="$output_file" bash "$script"
+}
+
+@test "configure-environment emits development environment outputs" {
+  run env \
+    ENVIRONMENT="development" \
+    APP_NAME="tariff-backend" \
+    SERVICE_NAMES="" \
+    REGION="eu-west-2" \
+    GITHUB_OUTPUT="$output_file" \
+    bash "$script"
+
+  [ "$status" -eq 0 ]
+  outputs="$(cat "$output_file")"
+  assert_contains "$outputs" "account-id=844815912454"
+  assert_contains "$outputs" "cluster=trade-tariff-cluster-development"
+  assert_contains "$outputs" "security-group-name=trade-tariff-ecs-security-group-development"
+  assert_contains "$outputs" "log-group=platform-logs-development"
+  assert_contains "$outputs" "slack-channel=deployments"
+  assert_contains "$outputs" "deploy-role-arn=arn:aws:iam::844815912454:role/GithubActions-ECS-Deployments-Role"
+  assert_contains "$outputs" "cleanup-role-arn=arn:aws:iam::844815912454:role/GithubActions-ECS-Task-Cleanup-Role"
+  assert_contains "$outputs" "ecr-url=382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-backend-production"
+}
+
+@test "configure-environment emits identity deploy role for identity app" {
+  run env \
+    ENVIRONMENT="production" \
+    APP_NAME="tariff-identity" \
+    SERVICE_NAMES="" \
+    REGION="eu-west-2" \
+    GITHUB_OUTPUT="$output_file" \
+    bash "$script"
+
+  [ "$status" -eq 0 ]
+  outputs="$(cat "$output_file")"
+  assert_contains "$outputs" "account-id=382373577178"
+  assert_contains "$outputs" "slack-channel=production-deployments"
+  assert_contains "$outputs" "deploy-role-arn=arn:aws:iam::382373577178:role/GithubActions-Identity-ECS-Deployments-Role"
+}
+
+@test "configure-environment emits identity deploy role for identity service control" {
+  run env \
+    ENVIRONMENT="staging" \
+    APP_NAME="" \
+    SERVICE_NAMES="frontend identity backend" \
+    REGION="eu-west-2" \
+    GITHUB_OUTPUT="$output_file" \
+    bash "$script"
+
+  [ "$status" -eq 0 ]
+  outputs="$(cat "$output_file")"
+  assert_contains "$outputs" "deploy-role-arn=arn:aws:iam::451934005581:role/GithubActions-Identity-ECS-Deployments-Role"
+}
+
+@test "configure-environment rejects unknown environments" {
+  run env \
+    ENVIRONMENT="preview" \
+    APP_NAME="tariff-backend" \
+    SERVICE_NAMES="" \
+    REGION="eu-west-2" \
+    GITHUB_OUTPUT="$output_file" \
+    bash "$script"
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Invalid environment: preview"
+}

--- a/tests/configure-environment-consumers.bats
+++ b/tests/configure-environment-consumers.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "service control actions use configure-environment outputs" {
+  start_action="$repo_root/.github/actions/start-services/action.yml"
+  stop_action="$repo_root/.github/actions/stop-services/action.yml"
+
+  run grep -F "trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main" "$start_action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "role-to-assume: \${{ steps.config.outputs.deploy-role-arn }}" "$start_action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "CLUSTER=\"\${{ steps.config.outputs.cluster }}\"" "$start_action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main" "$stop_action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "role-to-assume: \${{ steps.config.outputs.deploy-role-arn }}" "$stop_action"
+  [ "$status" -eq 0 ]
+
+  run grep -F "CLUSTER=\"\${{ steps.config.outputs.cluster }}\"" "$stop_action"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy workflow uses configure-environment for deployment outputs" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "id: environment-config" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "ecr_url=\${{ steps.environment-config.outputs.ecr-url }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "iam_role_arn=\${{ steps.environment-config.outputs.deploy-role-arn }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "slack_channel=\${{ steps.environment-config.outputs.slack-channel }}" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "task definition maintenance workflows use cleanup role from configure-environment" {
+  cleanup_workflow="$repo_root/.github/workflows/cleanup-unused-task-families.yml"
+  rotate_workflow="$repo_root/.github/workflows/rotate-task-definitions.yml"
+
+  cleanup_count=$(grep -F -c "trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main" "$cleanup_workflow" || true)
+  [ "$cleanup_count" -eq 3 ]
+
+  rotate_count=$(grep -F -c "trade-tariff/trade-tariff-tools/.github/actions/configure-environment@main" "$rotate_workflow" || true)
+  [ "$rotate_count" -eq 3 ]
+
+  run grep -F "role-to-assume: \${{ steps.config.outputs.cleanup-role-arn }}" "$cleanup_workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "role-to-assume: \${{ steps.config.outputs.cleanup-role-arn }}" "$rotate_workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added `.github/actions/configure-environment` to derive shared environment outputs
- [x] Updated deploy, service-control, cleanup, and rotation workflows/actions to consume shared outputs instead of repeating account and role mappings
- [x] Added Bats tests for the configure action and its workflow/action consumers

### Why?

I am doing this because:

- Account IDs, role ARNs, cluster names, Slack channels, and related environment facts were duplicated across workflows and composite actions.
- The checked-out sibling repos do not directly call these reusable workflows locally, so the existing workflow/action inputs remain the compatibility target.
- Centralising these outputs makes future environment changes local to one action.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages