### PR TITLE
Refactor database migration command

### DIFF
--- a/.github/actions/db-migrate/action.yml
+++ b/.github/actions/db-migrate/action.yml
@@ -26,17 +26,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Configure output variables
-      shell: bash
-      id: configure
-      run: |
-        REPO="${{ inputs.app-name }}"
-        REPO="${REPO#tariff-}"
-        {
-          echo "repo=${REPO}"
-          echo "task=${REPO}-job"
-        } >> "$GITHUB_OUTPUT"
-
     - uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
@@ -50,63 +39,13 @@ runs:
       shell: bash
       run: cd terraform && terraform init -backend-config=backends/${{ inputs.environment }}.tfbackend
 
-    - name: Update job task
-      id: update-job-task
-      shell: bash
-      env:
-        TF_VAR_docker_tag: ${{ inputs.ref }}
-      run: |
-        cd terraform
-
-        terraform apply \
-          -var-file=config_${{ inputs.environment }}.tfvars \
-          -auto-approve \
-          -lock-timeout=10m \
-          -target=module.${{ steps.configure.outputs.task }}
-
-        task_definition_arn=$(terraform state show "module.${{ steps.configure.outputs.task }}.aws_ecs_task_definition.this" \
-          | awk -F'= ' '/^[[:space:]]*arn[[:space:]]+=/ { gsub(/"/, "", $2); print $2; exit }')
-
-        if [ -z "${task_definition_arn}" ]; then
-          echo "::error::Could not determine updated task definition ARN"
-          exit 1
-        fi
-
-        echo "task-definition-arn=${task_definition_arn}" >> "$GITHUB_OUTPUT"
-
-    # For the admin and dev-hub services, there is only one search path to
-    # apply migrations to, so this runs one task
-    - name: Apply database migration
-      if: ${{ steps.configure.outputs.repo != 'backend' }}
+    - name: Apply database migrations
       shell: bash
       run: |
-        echo "::notice::Running migration task in ${{ inputs.environment }}..."
-
-        ${{ github.action_path }}/../../../bin/run-task \
-          -e ${{ inputs.environment }} \
-          -t ${{ steps.configure.outputs.task }} \
-          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
-          -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","command":["/bin/sh","-c","bundle exec rails db:migrate"]}]}'
-
-    # The backend service needs to run database migrations twice, once for each
-    # search path - so this custom behaviour runs instead
-    - name: Apply database migrations for backend service
-      if: ${{ steps.configure.outputs.repo == 'backend' }}
-      shell: bash
-      run: |
-        echo "::notice::Running migration task for UK schema in ${{ inputs.environment }}..."
-        ${{ github.action_path }}/../../../bin/run-task \
-          -e ${{ inputs.environment }} \
-          -t ${{ steps.configure.outputs.task }} \
-          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
-          -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","environment":[{"name":"SERVICE","value":"uk"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
-
-        echo "::notice::Running migration task for XI schema in ${{ inputs.environment }}..."
-        ${{ github.action_path }}/../../../bin/run-task \
-          -e ${{ inputs.environment }} \
-          -t ${{ steps.configure.outputs.task }} \
-          -d ${{ steps.update-job-task.outputs.task-definition-arn }} \
-          -o '{"containerOverrides":[{"name":"${{ steps.configure.outputs.task }}","environment":[{"name":"SERVICE","value":"xi"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
+        ${{ github.action_path }}/../../../bin/db-migrate \
+          --app-name ${{ inputs.app-name }} \
+          --environment ${{ inputs.environment }} \
+          --ref ${{ inputs.ref }}
 
     - name: Force unlock terraform state on cancellation
       if: cancelled()

--- a/bin/db-migrate
+++ b/bin/db-migrate
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+run_task="${DB_MIGRATE_RUN_TASK:-$script_dir/run-task}"
+
+app_name=""
+environment=""
+ref=""
+
+usage() {
+  cat <<EOF
+Usage: db-migrate --app-name APP --environment ENV --ref REF
+
+Runs the ECS database migration task for a deployed Tariff app.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-name)
+      app_name="$2"
+      shift 2
+      ;;
+    --environment)
+      environment="$2"
+      shift 2
+      ;;
+    --ref)
+      ref="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$app_name" || -z "$environment" || -z "$ref" ]]; then
+  usage >&2
+  exit 1
+fi
+
+repo="${app_name#tariff-}"
+task="${repo}-job"
+
+cd terraform
+
+TF_VAR_docker_tag="$ref" terraform apply \
+  -var-file="config_${environment}.tfvars" \
+  -auto-approve \
+  -lock-timeout=10m \
+  -target="module.${task}"
+
+task_definition_arn=$(terraform state show "module.${task}.aws_ecs_task_definition.this" \
+  | awk -F'= ' '/^[[:space:]]*arn[[:space:]]+=/ { gsub(/"/, "", $2); print $2; exit }')
+
+if [[ -z "$task_definition_arn" ]]; then
+  echo "Could not determine updated task definition ARN" >&2
+  exit 1
+fi
+
+cd ..
+
+if [[ "$repo" != "backend" ]]; then
+  echo "::notice::Running migration task in $environment..."
+  "$run_task" \
+    -e "$environment" \
+    -t "$task" \
+    -d "$task_definition_arn" \
+    -o '{"containerOverrides":[{"name":"'"$task"'","command":["/bin/sh","-c","bundle exec rails db:migrate"]}]}'
+  exit 0
+fi
+
+echo "::notice::Running migration task for UK schema in $environment..."
+"$run_task" \
+  -e "$environment" \
+  -t "$task" \
+  -d "$task_definition_arn" \
+  -o '{"containerOverrides":[{"name":"'"$task"'","environment":[{"name":"SERVICE","value":"uk"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'
+
+echo "::notice::Running migration task for XI schema in $environment..."
+"$run_task" \
+  -e "$environment" \
+  -t "$task" \
+  -d "$task_definition_arn" \
+  -o '{"containerOverrides":[{"name":"'"$task"'","environment":[{"name":"SERVICE","value":"xi"}],"command":["/bin/sh","-c","bundle exec rails db:migrate && bundle exec rails data:migrate"]}]}'

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -2,32 +2,39 @@
 
 load test_helper
 
-@test "db-migrate passes the updated task definition ARN to every migration task" {
+@test "db-migrate action delegates migration orchestration to bin/db-migrate" {
   action="$repo_root/.github/actions/db-migrate/action.yml"
 
-  run grep -F "id: update-job-task" "$action"
+  run grep -F "../../../bin/db-migrate" "$action"
   [ "$status" -eq 0 ]
 
-  run grep -F "task-definition-arn=" "$action"
+  run grep -F -- "--app-name \${{ inputs.app-name }}" "$action"
   [ "$status" -eq 0 ]
 
-  count=$(grep -F -c -- '-d ${{ steps.update-job-task.outputs.task-definition-arn }}' "$action" || true)
-  [ "$count" -eq 3 ]
+  run grep -F -- "--environment \${{ inputs.environment }}" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F -- "--ref \${{ inputs.ref }}" "$action"
+  [ "$status" -eq 0 ]
 }
 
-@test "db-migrate derives the job task from the deployed app name" {
+@test "db-migrate command derives the job task from the deployed app name" {
+  script="$repo_root/bin/db-migrate"
+
+  run grep -F 'repo="${app_name#tariff-}"' "$script"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'task="${repo}-job"' "$script"
+  [ "$status" -eq 0 ]
+}
+
+@test "db-migrate action passes the deployed app name to the command" {
   action="$repo_root/.github/actions/db-migrate/action.yml"
 
   run grep -F "app-name:" "$action"
   [ "$status" -eq 0 ]
 
-  run grep -F 'REPO="${{ inputs.app-name }}"' "$action"
-  [ "$status" -eq 0 ]
-
-  run grep -F 'REPO="${REPO#tariff-}"' "$action"
-  [ "$status" -eq 0 ]
-
-  run grep -F 'echo "repo=${REPO}"' "$action"
+  run grep -F -- "--app-name \${{ inputs.app-name }}" "$action"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/db-migrate-command.bats
+++ b/tests/db-migrate-command.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  setup_stub_path
+
+  mkdir -p "$tmpdir/project/terraform"
+  touch "$tmpdir/project/terraform/config_development.tfvars"
+
+  cat > "$stub_bin/terraform" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/terraform-calls.txt"
+
+case "$1" in
+  apply)
+    exit 0
+    ;;
+  state)
+    cat <<'STATE'
+# module.backend-job.aws_ecs_task_definition.this:
+arn = "arn:aws:ecs:eu-west-2:123456789012:task-definition/backend-job-123456789012:42"
+STATE
+    ;;
+  *)
+    echo "unexpected terraform command: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/terraform"
+
+  run_task_stub="$tmpdir/run-task"
+  cat > "$run_task_stub" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/run-task-calls.txt"
+STUB
+  chmod +x "$run_task_stub"
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+run_db_migrate() {
+  (
+    cd "$tmpdir/project"
+    TEST_CAPTURE_DIR="$tmpdir" DB_MIGRATE_RUN_TASK="$run_task_stub" "$repo_root/bin/db-migrate" "$@"
+  )
+}
+
+@test "db-migrate runs one migration task for non-backend apps" {
+  run run_db_migrate \
+    --app-name tariff-admin \
+    --environment development \
+    --ref abc123
+
+  [ "$status" -eq 0 ]
+  terraform_calls="$(cat "$tmpdir/terraform-calls.txt")"
+  run_task_calls="$(cat "$tmpdir/run-task-calls.txt")"
+
+  assert_contains "$terraform_calls" "apply -var-file=config_development.tfvars -auto-approve -lock-timeout=10m -target=module.admin-job"
+  assert_contains "$terraform_calls" "state show module.admin-job.aws_ecs_task_definition.this"
+  assert_contains "$run_task_calls" "-e development -t admin-job -d arn:aws:ecs:eu-west-2:123456789012:task-definition/backend-job-123456789012:42"
+  assert_contains "$run_task_calls" "\"command\":[\"/bin/sh\",\"-c\",\"bundle exec rails db:migrate\"]"
+}
+
+@test "db-migrate runs UK and XI migration tasks for backend" {
+  run run_db_migrate \
+    --app-name tariff-backend \
+    --environment development \
+    --ref abc123
+
+  [ "$status" -eq 0 ]
+  run_task_calls="$(cat "$tmpdir/run-task-calls.txt")"
+
+  call_count="$(wc -l < "$tmpdir/run-task-calls.txt" | tr -d ' ')"
+  [ "$call_count" -eq 2 ]
+  assert_contains "$run_task_calls" "\"environment\":[{\"name\":\"SERVICE\",\"value\":\"uk\"}]"
+  assert_contains "$run_task_calls" "\"environment\":[{\"name\":\"SERVICE\",\"value\":\"xi\"}]"
+  assert_contains "$run_task_calls" "bundle exec rails db:migrate && bundle exec rails data:migrate"
+}
+
+@test "db-migrate requires app name environment and ref" {
+  run "$repo_root/bin/db-migrate" --app-name tariff-admin --environment development
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Usage:"
+}


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added `bin/db-migrate` as the executable migration orchestration seam
- [x] Simplified `.github/actions/db-migrate` so the composite action delegates to the executable while keeping its inputs unchanged
- [x] Added Bats coverage for non-backend migrations, backend UK/XI migrations, required arguments, and action delegation

### Why?

I am doing this because:

- The database migration action mixed Terraform task refresh, task-definition extraction, and migration branching inside YAML.
- Moving that behavior behind a command makes it easier to test through a real executable interface.
- The checked-out sibling repos do not directly consume the action locally, so preserving the `db-migrate` action inputs is the compatibility target.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages
