### PR TITLE
Include PR title and risk label in Slack deploy notifications

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -258,37 +258,11 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          SHA="${{ needs.configure.outputs.actual_ref }}"
-          REPO="${{ needs.configure.outputs.actual_repo }}"
-
-          PR_DATA=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
-            -H "Accept: application/vnd.github+json" \
-            --jq '.[0] // empty' 2>/dev/null || true)
-
-          if [[ -z "$PR_DATA" ]]; then
-            echo "message=Deploy to ${{ inputs.environment }} ${{ steps.result.outputs.result }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
-          PR_URL=$(echo "$PR_DATA" | jq -r '.html_url')
-          RISK_LABEL=$(echo "$PR_DATA" | jq -r '[.labels[].name | select(test("risk"))] | .[0] // empty')
-
-          MESSAGE="Deploy to ${{ inputs.environment }} ${{ steps.result.outputs.result }}\n*<${PR_URL}|#${PR_NUMBER} — ${PR_TITLE}>*"
-
-          if [[ -n "$RISK_LABEL" ]]; then
-            case "$RISK_LABEL" in
-              low-risk)    RISK_EMOJI=":large_green_circle:" ;;
-              medium-risk) RISK_EMOJI=":large_yellow_circle:" ;;
-              high-risk)   RISK_EMOJI=":red_circle:" ;;
-              *)           RISK_EMOJI=":white_circle:" ;;
-            esac
-            MESSAGE="${MESSAGE}\nRisk: ${RISK_EMOJI} ${RISK_LABEL}"
-          fi
-
-          echo "message=${MESSAGE}" >> "$GITHUB_OUTPUT"
+          SHA: ${{ needs.configure.outputs.actual_ref }}
+          REPO: ${{ needs.configure.outputs.actual_repo }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          RESULT: ${{ steps.result.outputs.result }}
+        run: bash scripts/notify-pr-info.sh
 
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -59,6 +59,11 @@ on:
         description: 'Password for admin bypass'
         required: false
 
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: read
+
 jobs:
   configure:
     runs-on: ubuntu-latest
@@ -248,11 +253,48 @@ jobs:
           else
             echo "result=${{ needs.deploy.result }}" >> "$GITHUB_OUTPUT"
           fi
+
+      - id: pr-info
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA="${{ needs.configure.outputs.actual_ref }}"
+          REPO="${{ needs.configure.outputs.actual_repo }}"
+
+          PR_DATA=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+            -H "Accept: application/vnd.github+json" \
+            --jq '.[0] // empty' 2>/dev/null || true)
+
+          if [[ -z "$PR_DATA" ]]; then
+            echo "message=Deploy to ${{ inputs.environment }} ${{ steps.result.outputs.result }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+          PR_URL=$(echo "$PR_DATA" | jq -r '.html_url')
+          RISK_LABEL=$(echo "$PR_DATA" | jq -r '[.labels[].name | select(test("risk"))] | .[0] // empty')
+
+          MESSAGE="Deploy to ${{ inputs.environment }} ${{ steps.result.outputs.result }}\n*<${PR_URL}|#${PR_NUMBER} — ${PR_TITLE}>*"
+
+          if [[ -n "$RISK_LABEL" ]]; then
+            case "$RISK_LABEL" in
+              low-risk)    RISK_EMOJI=":large_green_circle:" ;;
+              medium-risk) RISK_EMOJI=":large_yellow_circle:" ;;
+              high-risk)   RISK_EMOJI=":red_circle:" ;;
+              *)           RISK_EMOJI=":white_circle:" ;;
+            esac
+            MESSAGE="${MESSAGE}\nRisk: ${RISK_EMOJI} ${RISK_LABEL}"
+          fi
+
+          echo "message=${MESSAGE}" >> "$GITHUB_OUTPUT"
+
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:
           webhook: ${{ secrets.slack-webhook }}
           channel: ${{ needs.configure.outputs.slack_channel }}
           color: ${{ steps.result.outputs.result }}
           title: "${{ github.workflow }}"
-          message: "Deploy to ${{ inputs.environment }} ${{ steps.result.outputs.result }}"
+          message: "${{ steps.pr-info.outputs.message || format('Deploy to {0} {1}', inputs.environment, steps.result.outputs.result) }}"
       - run: if [[ "${{ steps.result.outputs.result }}" != "success" ]]; then exit 1; fi

--- a/scripts/notify-pr-info.sh
+++ b/scripts/notify-pr-info.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
 
 # Looks up the PR associated with a deployed commit and writes a composed
 # Slack message to GITHUB_OUTPUT. Falls back to a plain message if the API

--- a/scripts/notify-pr-info.sh
+++ b/scripts/notify-pr-info.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Looks up the PR associated with a deployed commit and writes a composed
+# Slack message to GITHUB_OUTPUT. Falls back to a plain message if the API
+# call fails or no PR is found.
+#
+# Required env vars:
+#   SHA         - the deployed commit SHA
+#   REPO        - the GitHub repository (owner/name)
+#   ENVIRONMENT - the deployment target (e.g. "production")
+#   RESULT      - the deploy result (e.g. "success")
+#   GITHUB_OUTPUT - path to the GitHub Actions output file
+
+FALLBACK="Deploy to ${ENVIRONMENT} ${RESULT}"
+
+PR_DATA=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
+  -H "Accept: application/vnd.github+json" \
+  --jq '.[0] // empty' 2>/dev/null || true)
+
+if [[ -z "$PR_DATA" ]]; then
+  echo "message=${FALLBACK}" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
+PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+PR_URL=$(echo "$PR_DATA" | jq -r '.html_url')
+RISK_LABEL=$(echo "$PR_DATA" | jq -r '[.labels[].name | select(test("risk"))] | .[0] // empty')
+
+MESSAGE="${FALLBACK}\n*<${PR_URL}|#${PR_NUMBER} — ${PR_TITLE}>*"
+
+if [[ -n "$RISK_LABEL" ]]; then
+  case "$RISK_LABEL" in
+    low-risk)    RISK_EMOJI=":large_green_circle:" ;;
+    medium-risk) RISK_EMOJI=":large_yellow_circle:" ;;
+    high-risk)   RISK_EMOJI=":red_circle:" ;;
+    *)           RISK_EMOJI=":white_circle:" ;;
+  esac
+  MESSAGE="${MESSAGE}\nRisk: ${RISK_EMOJI} ${RISK_LABEL}"
+fi
+
+echo "message=${MESSAGE}" >> "$GITHUB_OUTPUT"

--- a/tests/notify-pr-info.bats
+++ b/tests/notify-pr-info.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  setup_stub_path
+  export GITHUB_OUTPUT="$tmpdir/github_output"
+  touch "$GITHUB_OUTPUT"
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+make_gh_stub() {
+  local response="$1"
+  cat > "$stub_bin/gh" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' '${response}'
+STUB
+  chmod +x "$stub_bin/gh"
+}
+
+run_script() {
+  run env \
+    SHA="abc1234" \
+    REPO="trade-tariff/example" \
+    ENVIRONMENT="production" \
+    RESULT="success" \
+    GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+    bash "$repo_root/scripts/notify-pr-info.sh"
+}
+
+@test "outputs a plain fallback message when the API returns no PR" {
+  make_gh_stub ""
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "message=Deploy to production success"
+}
+
+@test "outputs PR title and link when a PR is found" {
+  make_gh_stub '{"number":99,"title":"My great change","html_url":"https://github.com/trade-tariff/example/pull/99","labels":[]}'
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#99 — My great change"
+  assert_contains "$output_content" "https://github.com/trade-tariff/example/pull/99"
+}
+
+@test "omits the risk line when the PR has no risk label" {
+  make_gh_stub '{"number":99,"title":"My great change","html_url":"https://github.com/trade-tariff/example/pull/99","labels":[{"name":"bug"}]}'
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_not_contains "$output_content" "Risk:"
+}
+
+@test "includes a green circle for low-risk PRs" {
+  make_gh_stub '{"number":1,"title":"Tiny fix","html_url":"https://github.com/trade-tariff/example/pull/1","labels":[{"name":"low-risk"}]}'
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" ":large_green_circle:"
+  assert_contains "$output_content" "low-risk"
+}
+
+@test "includes a yellow circle for medium-risk PRs" {
+  make_gh_stub '{"number":2,"title":"Bigger change","html_url":"https://github.com/trade-tariff/example/pull/2","labels":[{"name":"medium-risk"}]}'
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" ":large_yellow_circle:"
+  assert_contains "$output_content" "medium-risk"
+}
+
+@test "includes a red circle for high-risk PRs" {
+  make_gh_stub '{"number":3,"title":"Dangerous change","html_url":"https://github.com/trade-tariff/example/pull/3","labels":[{"name":"high-risk"}]}'
+
+  run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" ":red_circle:"
+  assert_contains "$output_content" "high-risk"
+}
+
+@test "deploy-ecs calls the notify-pr-info script in the pr-info step" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "bash scripts/notify-pr-info.sh" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs pr-info step has continue-on-error set" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "continue-on-error: true" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs slack-notify message falls back when pr-info produces no output" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "steps.pr-info.outputs.message ||" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds a `pr-info` step to the `notify` job in `deploy-ecs.yml` that looks up the PR associated with the deployed commit via the GitHub API
- Slack messages now include the PR title, number, and a link, plus a colour-coded risk label emoji when one is present (`low-risk` / `medium-risk` / `high-risk`)
- Repos without risk labels are handled naturally — the risk line is omitted when no matching label is found
- Adds `pull-requests: read` to the workflow-level permissions block (required for the commits→pulls API endpoint)

## Fail-safe behaviour

The PR info lookup is best-effort:
- `continue-on-error: true` on `pr-info` swallows any API failure, network timeout, or parsing error without failing the notify job
- The `message:` input to `slack-notify` falls back to the plain `Deploy to {env} {result}` string if `pr-info` wrote nothing to its output — so a Slack notification is always sent
