### PR TITLE
Remove pull-requests: read from deploy-ecs.yml

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -62,7 +62,6 @@ on:
 permissions:
   contents: read
   id-token: write
-  pull-requests: read
 
 jobs:
   configure:


### PR DESCRIPTION
## Summary

Fixes a workflow validation failure introduced in #144.

Reusable workflows can't request permissions that the caller doesn't grant. Caller workflows across all repos only declare `contents: read` and `id-token: write`, so adding `pull-requests: read` to `deploy-ecs.yml` causes GitHub to reject the workflow as invalid before it even runs.

The `pr-info` step already has `continue-on-error: true` and the `slack-notify` message input has a fallback expression, so when the token lacks pull-requests access the step fails silently and the plain fallback message is sent to Slack instead. PR enrichment is best-effort by design.

## Risk

low-risk — removes a permissions declaration, no behaviour change for repos where the token already has pull-requests access (org default read-all), and a safe fallback for those that don't.