### PR TITLE
Fix Slack notification newlines

### DIFF
--- a/.github/actions/slack-notify/action.yml
+++ b/.github/actions/slack-notify/action.yml
@@ -53,6 +53,8 @@ runs:
           cancelled) COLOR="#808080" ;;
         esac
 
+        MESSAGE="${MESSAGE//\\n/$'\n'}"
+
         FOOTER="${GITHUB_REPOSITORY} | <${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}|View workflow run>"
 
         PAYLOAD=$(jq -n \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/close-stale-pull-requests-reusable.yml'
       - '.github/actions/db-migrate/**'
+      - '.github/actions/slack-notify/**'
       - 'bin/cleanup-ecs-families'
       - 'bin/run-task'
       - 'bin/rotate-task-definitions'

--- a/tests/slack-notify-action.bats
+++ b/tests/slack-notify-action.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  script="$tmpdir/slack-notify.sh"
+  payload_file="$tmpdir/payload.json"
+
+  ruby -ryaml -e 'puts YAML.load_file(ARGV.fetch(0)).fetch("runs").fetch("steps").fetch(0).fetch("run")' \
+    "$repo_root/.github/actions/slack-notify/action.yml" > "$script"
+
+  setup_stub_path
+  cat > "$stub_bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload=""
+
+while (($#)); do
+  case "$1" in
+    -d|--data|--data-raw|--data-binary)
+      shift
+      payload="$1"
+      ;;
+  esac
+  shift || true
+done
+
+printf '%s' "$payload" > "$TEST_PAYLOAD_FILE"
+printf 'ok'
+STUB
+  chmod +x "$stub_bin/curl"
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+run_slack_notify() {
+  TEST_PAYLOAD_FILE="$payload_file" env \
+    WEBHOOK="https://hooks.slack.test/services/test" \
+    CHANNEL="production-deployments" \
+    USERNAME="Deploy Bot" \
+    ICON_EMOJI=":robot_face:" \
+    COLOR="success" \
+    TITLE="Deploy to production" \
+    MESSAGE='Deploy to production success\n*#258 - Bump govuk-components*' \
+    GITHUB_REPOSITORY="trade-tariff/identity" \
+    GITHUB_SERVER_URL="https://github.com" \
+    GITHUB_RUN_ID="12345" \
+    GITHUB_ACTOR="neilmiddleton" \
+    bash "$script"
+}
+
+@test "slack-notify converts escaped newline sequences in message input" {
+  run run_slack_notify
+
+  [ "$status" -eq 0 ]
+
+  text="$(ruby -rjson -e 'print JSON.parse(File.read(ARGV.fetch(0))).fetch("attachments").fetch(0).fetch("text")' "$payload_file")"
+
+  [[ "$text" == $'Deploy to production success\n*#258 - Bump govuk-components*' ]]
+  [[ "$text" != *'\\n'* ]]
+}


### PR DESCRIPTION
### Jira link

No ticket/issue

<img width="1089" height="224" alt="image" src="https://github.com/user-attachments/assets/ab297498-514a-4b7e-8543-1e18bc8e4c21" />


### What?

- [x] Convert escaped `\n` sequences in `slack-notify` messages into real newline characters before building the Slack payload
- [x] Add Bats coverage for the Slack payload text
- [x] Add `slack-notify` to CI path filters so action changes trigger tests

### Why?

Deploy notifications can include PR metadata on a second line. The deploy workflow writes that line as `\n` in the job output, but the Slack action sent the string through unchanged. Slack rendered the two characters `\n` instead of starting a new line.

Normalising the message in the shared Slack action fixes the current deploy notifications without changing each caller.

### Risk

**Risk level:** 🟢

**Reason for rating:** Low-risk notification formatting change with focused regression coverage. No deployment behaviour or AWS permissions change.