### PR TITLE
Respect stacked PRs in line count action

### DIFF
--- a/.github/actions/check-pr-lines/action.yml
+++ b/.github/actions/check-pr-lines/action.yml
@@ -41,12 +41,14 @@ runs:
 
         base_sha="$INPUT_BASE_SHA"
         head_sha="$INPUT_HEAD_SHA"
+        base_ref=""
 
         if [[ -z "$base_sha" || -z "$head_sha" ]]; then
           case "${{ github.event_name }}" in
             pull_request)
               base_sha="${{ github.event.pull_request.base.sha }}"
               head_sha="${{ github.event.pull_request.head.sha }}"
+              base_ref="${{ github.event.pull_request.base.ref }}"
               ;;
             push)
               response="$(
@@ -60,6 +62,7 @@ runs:
                 exit 0
               fi
               base_sha="$(jq -r '.[0].base.sha' <<< "$response")"
+              base_ref="$(jq -r '.[0].base.ref' <<< "$response")"
               head_sha="$(jq -r '.[0].head.sha' <<< "$response")"
               ;;
             *)
@@ -80,5 +83,6 @@ runs:
         "${{ github.action_path }}/check-pr-lines.sh" \
           --threshold "$THRESHOLD" \
           --base "$base_sha" \
+          --base-ref "$base_ref" \
           --head "$head_sha" \
           --exclude-paths-file "$exclude_file"

--- a/.github/actions/check-pr-lines/check-pr-lines.sh
+++ b/.github/actions/check-pr-lines/check-pr-lines.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: check-pr-lines.sh --threshold <n> --base <sha> --head <sha> [--exclude-paths-file <file>]
+Usage: check-pr-lines.sh --threshold <n> --base <sha> --head <sha> [--base-ref <ref>] [--exclude-paths-file <file>]
 
 Counts additions and deletions between two commits (after optional path exclusions)
 and exits 1 when the total exceeds the threshold.
@@ -13,6 +13,7 @@ EOF
 threshold=""
 base_sha=""
 head_sha=""
+base_ref=""
 exclude_paths_file=""
 
 while [[ $# -gt 0 ]]; do
@@ -27,6 +28,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --head)
       head_sha="$2"
+      shift 2
+      ;;
+    --base-ref)
+      base_ref="$2"
       shift 2
       ;;
     --exclude-paths-file)
@@ -56,7 +61,14 @@ if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
-merge_base="$(git merge-base "$base_sha" "$head_sha")"
+merge_base_input="$base_sha"
+if [[ -n "$base_ref" ]] && git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+  merge_base_input="$base_ref"
+elif [[ -n "$base_ref" ]] && git rev-parse --verify --quiet "origin/$base_ref" >/dev/null; then
+  merge_base_input="origin/$base_ref"
+fi
+
+merge_base="$(git merge-base "$merge_base_input" "$head_sha")"
 
 exclude_specs=()
 if [[ -n "$exclude_paths_file" && -f "$exclude_paths_file" ]]; then

--- a/tests/check-pr-lines.bats
+++ b/tests/check-pr-lines.bats
@@ -91,3 +91,33 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"PR changes 1 lines"* ]]
 }
+
+@test "counts stacked pull request changes from the merge base of the base ref" {
+  git -C "$repo" switch -qc parent-pr "$base_sha"
+  printf 'parent change\n' > "$repo/parent.txt"
+  git -C "$repo" add parent.txt
+  git -C "$repo" commit -qm "parent change"
+  parent_original_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" switch -qc child-pr "$parent_original_sha"
+  printf 'child change\n' > "$repo/child.txt"
+  git -C "$repo" add child.txt
+  git -C "$repo" commit -qm "child change"
+  child_head_sha="$(git -C "$repo" rev-parse HEAD)"
+
+  git -C "$repo" switch parent-pr
+  printf 'parent follow-up\n' > "$repo/parent-follow-up.txt"
+  git -C "$repo" add parent-follow-up.txt
+  git -C "$repo" commit -qm "parent follow-up"
+
+  cd "$repo" || return 1
+
+  run bash "$script" \
+    --threshold 1 \
+    --base "$base_sha" \
+    --base-ref parent-pr \
+    --head "$child_head_sha"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR changes 1 lines"* ]]
+}


### PR DESCRIPTION
### Jira link

No Jira ticket.

### What?

I have altered:

- [x] Added optional `--base-ref` support to `check-pr-lines.sh`
- [x] Wired the composite action to pass the pull request base ref for `pull_request` and `push` events
- [x] Added a Bats regression for stacked pull requests where the base branch moves after the child branch is created

### Why?

Stacked pull requests should be counted against the merge base of their base branch and head commit. Passing the base ref gives the line count action the branch context it needs to calculate the stacked PR range reliably, while preserving the existing base SHA fallback.

### Risk

**Risk level:** 🟢

**Reason for rating:** Small GitHub Action helper change with Bats coverage and a fallback to the existing base SHA behaviour.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages
