### PR TITLE
Keep auto-merge waiting when Copilot request fails

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -79,7 +79,9 @@ runs:
           fi
 
           echo "Requesting Copilot code review for PR #$PR_NUMBER"
-          gh pr edit "$PR_NUMBER" --repo "$repo" --add-reviewer copilot
+          if ! gh pr edit "$PR_NUMBER" --repo "$repo" --add-reviewer copilot; then
+            echo "::warning::Unable to request Copilot code review for PR #$PR_NUMBER; auto-merge will retry after a review is available."
+          fi
         }
 
         # Label removed — turn off auto-merge.

--- a/tests/close-stale-pull-requests-reusable.bats
+++ b/tests/close-stale-pull-requests-reusable.bats
@@ -41,7 +41,8 @@ if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/branches" ]]; then
 fi
 
 if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/commits/sha-fresh" ]]; then
-  printf '%s\n' '{"commit":{"committer":{"date":"2026-06-03T12:00:00Z"}}}'
+  fresh_date="$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+  printf '{"commit":{"committer":{"date":"%s"}}}\n' "$fresh_date"
   exit 0
 fi
 


### PR DESCRIPTION
### Jira link

No Jira ticket/issue.

### What?

- [x] Keep the low-risk auto-merge action on its existing wait/retry path when GitHub refuses a Copilot review request.
- [x] Make the stale branch cleanup test fixture compute a fresh commit date dynamically.

### Why?

The low-risk auto-merge workflow currently fails when `gh pr edit --add-reviewer copilot` is rejected by GitHub token permissions, even though the intended behaviour is to wait for a Copilot review and retry on a later run.

### Risk

**Risk level:** 🟢

**Reason for rating:** Shared CI workflow fix with non-fatal handling for an existing retry path and local regression verification.
