### PR TITLE
HMRC-2407 improve log message on auto-merge FAIL exit 0

### DIFF
--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -113,6 +113,7 @@ while true; do
       -F pr="$pr" \
       -f cursor="$cursor" 2>&1)" || {
       if grep -qi "resource not accessible by personal access token" <<< "$response"; then
+        echo "::warning::Insufficient token permissions to check Copilot review threads. Skipping detailed review gate check. This allows workflow to continue." >&2
         exit 0
       fi
       echo "$response" >&2
@@ -142,6 +143,7 @@ while true; do
       -f repo="$name" \
       -F pr="$pr" 2>&1)" || {
       if grep -qi "resource not accessible by personal access token" <<< "$response"; then
+        echo "::warning::Insufficient token permissions to check Copilot review threads. Skipping detailed review gate check. This allows workflow to continue." >&2
         exit 0
       fi
       echo "$response" >&2


### PR DESCRIPTION
### Jira link

HMRC-2407

### What?

I have added/removed/altered:

- [ ]  Added log message to indicate lack of token permission scope and still exit 0 to allow WF to continue

### Why?

I am doing this because:

- [ ]  the script will exit 0 on FAIL due to insufficient token permission

- [ ] The PAT needs the pull-requests:read scope (or the broader repo scope) to access:
repository.pullRequest.reviewRequests.nodes.requestedReviewer

- [ ]  should have at least:

✅ pull-requests:read (or repo for full access)

✅ pull-requests:write (needed to enable auto-merge)

✅ contents:read (likely already present)

-
-
-

### Have you? (optional)

- [ ✅ ] Clearly documented/self-documented any scripts I've added
- [ 🙏 ] Respected people's right not to receive lots of noisy messages
