### PR TITLE
Fix deploy PR notification titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/ci.yml'
       - '.github/workflows/close-stale-pull-requests-reusable.yml'
+      - '.github/workflows/deploy-ecs.yml'
       - '.github/actions/db-migrate/**'
       - 'bin/cleanup-ecs-families'
       - 'bin/run-task'
@@ -12,6 +13,7 @@ on:
       - '.github/actions/auto-merge-low-risk/**'
       - '.github/actions/check-pr-lines/**'
       - '.github/workflows/auto-merge-low-risk.yml'
+      - 'scripts/deploy-pr-info.sh'
       - 'scripts/trufflehog-pre-commit.sh'
       - 'tests/**'
 
@@ -31,7 +33,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
+        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -86,7 +86,7 @@ jobs:
           if [[ -n "${{ inputs.checkout-ref }}" ]]; then
             ACTUAL_REF="${{ inputs.checkout-ref }}"
           elif [[ "$ACTUAL_REPO" == "${{ github.repository }}" ]]; then
-            ACTUAL_REF="${{ github.event.pull_request.head.sha || github.sha }}"
+            ACTUAL_REF="${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}"
           else
             ACTUAL_REF="main"
           fi
@@ -221,6 +221,20 @@ jobs:
         with:
           repository: ${{ needs.configure.outputs.actual_repo }}
           ref: ${{ needs.configure.outputs.actual_ref }}
+      - id: workflow-source
+        env:
+          JOB_CONTEXT: ${{ toJson(job) }}
+        run: |
+          {
+            echo "repository=$(echo "$JOB_CONTEXT" | jq -r '.workflow_repository')"
+            echo "sha=$(echo "$JOB_CONTEXT" | jq -r '.workflow_sha')"
+          } >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v6.0.3
+        with:
+          repository: ${{ steps.workflow-source.outputs.repository }}
+          ref: ${{ steps.workflow-source.outputs.sha }}
+          path: .trade-tariff-tools
+          ssh-key: ${{ secrets.ssh-key }}
       - id: result
         run: |
           TEST_FLAVOUR="${{ inputs.test-flavour }}"
@@ -237,45 +251,14 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ needs.configure.outputs.docker_tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           SHA: ${{ needs.configure.outputs.actual_ref }}
-          REPO: ${{ needs.configure.outputs.actual_repo }}
+          TRIGGER_SHA: ${{ github.event.workflow_run.head_sha || github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha || github.sha }}
           ENVIRONMENT: ${{ inputs.environment }}
           RESULT: ${{ steps.result.outputs.result }}
-        run: |
-          FALLBACK="Deploy to ${ENVIRONMENT} ${RESULT}"
-
-          PR_DATA=$(gh api "repos/${REPO}/commits/${SHA}/pulls" \
-            -H "Accept: application/vnd.github+json" \
-            --jq '.[0] // empty' 2>/dev/null || true)
-
-          if [[ -z "$PR_DATA" ]]; then
-            echo "message=${FALLBACK}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-
-          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title')
-          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
-          PR_URL=$(echo "$PR_DATA" | jq -r '.html_url')
-          RISK_LABEL=$(echo "$PR_DATA" | jq -r '[.labels[].name | select(test("risk"))] | .[0] // empty')
-
-          MESSAGE="${FALLBACK}"$'\n'"*<${PR_URL}|#${PR_NUMBER} — ${PR_TITLE}>*"
-
-          if [[ -n "$RISK_LABEL" ]]; then
-            case "$RISK_LABEL" in
-              low-risk)    RISK_EMOJI=":large_green_circle:" ;;
-              medium-risk) RISK_EMOJI=":large_yellow_circle:" ;;
-              high-risk)   RISK_EMOJI=":red_circle:" ;;
-              *)           RISK_EMOJI=":white_circle:" ;;
-            esac
-            MESSAGE="${MESSAGE}"$'\n'"Risk: ${RISK_EMOJI} ${RISK_LABEL}"
-          fi
-
-          {
-            echo 'message<<NOTIFY_EOF'
-            echo "$MESSAGE"
-            echo 'NOTIFY_EOF'
-          } >> "$GITHUB_OUTPUT"
+        run: .trade-tariff-tools/scripts/deploy-pr-info.sh
 
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:

--- a/scripts/deploy-pr-info.sh
+++ b/scripts/deploy-pr-info.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+fallback="Deploy to ${ENVIRONMENT} ${RESULT}"
+
+append_message_output() {
+  local message="$1"
+
+  {
+    echo 'message<<NOTIFY_EOF'
+    echo "$message"
+    echo 'NOTIFY_EOF'
+  } >> "$GITHUB_OUTPUT"
+}
+
+gh_api() {
+  gh api "$@" 2>/dev/null || true
+}
+
+fetch_pr() {
+  local number="$1"
+
+  if [[ -z "$number" ]]; then
+    return 0
+  fi
+
+  gh_api "repos/${REPO}/pulls/${number}"
+}
+
+commit_title() {
+  local ref="$1"
+
+  if [[ -z "$ref" ]]; then
+    return 0
+  fi
+
+  gh_api "repos/${REPO}/commits/${ref}" --jq '.commit.message | split("\n")[0] // empty'
+}
+
+pull_request_number_from_title() {
+  local title="$1"
+
+  if [[ "$title" =~ ^Merge\ pull\ request\ \#([0-9]+)\  ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  elif [[ "$title" =~ \(\#([0-9]+)\)$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  fi
+}
+
+associated_pr() {
+  local ref="$1"
+
+  if [[ -z "$ref" ]]; then
+    return 0
+  fi
+
+  # shellcheck disable=SC2016
+  gh_api "repos/${REPO}/commits/${ref}/pulls" \
+    -H "Accept: application/vnd.github+json" \
+    --jq 'map(select(.merged_at != null)) as $merged | (($merged + .) | .[0]) // empty'
+}
+
+find_pr_data_for_ref() {
+  local ref="$1"
+  local title number pr_data
+
+  title="$(commit_title "$ref")"
+  number="$(pull_request_number_from_title "$title")"
+  pr_data="$(fetch_pr "$number")"
+
+  if [[ -n "$pr_data" ]]; then
+    printf '%s\n' "$pr_data"
+    return 0
+  fi
+
+  associated_pr "$ref"
+}
+
+find_pr_data() {
+  local pr_data ref seen_refs
+  seen_refs=" "
+
+  pr_data="$(fetch_pr "${PR_NUMBER:-}")"
+  if [[ -n "$pr_data" ]]; then
+    printf '%s\n' "$pr_data"
+    return 0
+  fi
+
+  for ref in "${TRIGGER_SHA:-}" "${DEPLOY_SHA:-}" "${SHA:-}"; do
+    if [[ -z "$ref" || "$seen_refs" == *" $ref "* ]]; then
+      continue
+    fi
+
+    seen_refs="${seen_refs}${ref} "
+    pr_data="$(find_pr_data_for_ref "$ref")"
+
+    if [[ -n "$pr_data" ]]; then
+      printf '%s\n' "$pr_data"
+      return 0
+    fi
+  done
+}
+
+pr_data="$(find_pr_data)"
+
+if [[ -z "$pr_data" ]]; then
+  append_message_output "$fallback"
+  exit 0
+fi
+
+pr_title="$(echo "$pr_data" | jq -r '.title')"
+pr_number="$(echo "$pr_data" | jq -r '.number')"
+pr_url="$(echo "$pr_data" | jq -r '.html_url')"
+risk_label="$(echo "$pr_data" | jq -r '[.labels[].name | select(test("risk"))] | .[0] // empty')"
+
+message="${fallback}"$'\n'"*<${pr_url}|#${pr_number} — ${pr_title}>*"
+
+if [[ -n "$risk_label" ]]; then
+  case "$risk_label" in
+    low-risk)    risk_emoji=":large_green_circle:" ;;
+    medium-risk) risk_emoji=":large_yellow_circle:" ;;
+    high-risk)   risk_emoji=":red_circle:" ;;
+    *)           risk_emoji=":white_circle:" ;;
+  esac
+  message="${message}"$'\n'"Risk: ${risk_emoji} ${risk_label}"
+fi
+
+append_message_output "$message"

--- a/tests/notify-pr-info.bats
+++ b/tests/notify-pr-info.bats
@@ -22,26 +22,17 @@ STUB
   chmod +x "$stub_bin/gh"
 }
 
-extract_pr_info_script() {
-  ruby -ryaml -e '
-    workflow = YAML.load_file(ARGV.fetch(0))
-    steps = workflow.fetch("jobs").fetch("notify").fetch("steps")
-    step = steps.find { |s| s["id"] == "pr-info" }
-    puts step.fetch("run")
-  ' "$repo_root/.github/workflows/deploy-ecs.yml"
-}
-
 run_script() {
-  script="$tmpdir/pr-info.sh"
-  extract_pr_info_script > "$script"
-
   run env \
-    SHA="abc1234" \
+    DEPLOY_SHA="${DEPLOY_SHA:-abc1234}" \
+    PR_NUMBER="${PR_NUMBER:-}" \
     REPO="trade-tariff/example" \
+    SHA="${SHA:-abc1234}" \
+    TRIGGER_SHA="${TRIGGER_SHA:-}" \
     ENVIRONMENT="production" \
     RESULT="success" \
     GITHUB_OUTPUT="$GITHUB_OUTPUT" \
-    bash "$script"
+    "$repo_root/scripts/deploy-pr-info.sh"
 }
 
 @test "outputs a plain fallback message when the API returns no PR" {
@@ -51,7 +42,131 @@ run_script() {
 
   [ "$status" -eq 0 ]
   output_content="$(cat "$GITHUB_OUTPUT")"
-  assert_contains "$output_content" "message=Deploy to production success"
+  assert_contains "$output_content" "Deploy to production success"
+}
+
+@test "uses an explicit pull request number when the triggering event provides one" {
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "api" && "$2" == "repos/trade-tariff/example/pulls/123" ]]; then
+  printf '%s\n' '{"number":123,"title":"Triggered PR","html_url":"https://github.com/trade-tariff/example/pull/123","labels":[]}'
+fi
+STUB
+  chmod +x "$stub_bin/gh"
+
+  PR_NUMBER="123" run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#123 — Triggered PR"
+}
+
+@test "uses the trigger commit title before the deployed app commit" {
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" != "api" ]]; then
+  exit 1
+fi
+
+case "$2" in
+  repos/trade-tariff/example/commits/trigger-sha)
+    printf '%s\n' 'Merge pull request #456 from trade-tariff/HMRC-456-real-change'
+    ;;
+  repos/trade-tariff/example/pulls/456)
+    printf '%s\n' '{"number":456,"title":"Real triggering PR","html_url":"https://github.com/trade-tariff/example/pull/456","labels":[]}'
+    ;;
+  repos/trade-tariff/example/commits/deploy-sha)
+    printf '%s\n' 'Merge pull request #232 from trade-tariff/dependabot/faraday'
+    ;;
+  repos/trade-tariff/example/pulls/232)
+    printf '%s\n' '{"number":232,"title":"Bump faraday from 2.14.2 to 2.14.3","html_url":"https://github.com/trade-tariff/example/pull/232","labels":[]}'
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/gh"
+
+  TRIGGER_SHA="trigger-sha" DEPLOY_SHA="deploy-sha" run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#456 — Real triggering PR"
+  assert_not_contains "$output_content" "#232"
+}
+
+@test "parses merge commit titles to fetch the pull request by number" {
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" != "api" ]]; then
+  exit 1
+fi
+
+case "$2" in
+  repos/trade-tariff/example/commits/merge-sha)
+    printf '%s\n' 'Merge pull request #232 from trade-tariff/dependabot/faraday'
+    ;;
+  repos/trade-tariff/example/pulls/232)
+    printf '%s\n' '{"number":232,"title":"Bump faraday from 2.14.2 to 2.14.3","html_url":"https://github.com/trade-tariff/example/pull/232","labels":[{"name":"low-risk"}]}'
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/gh"
+
+  SHA="merge-sha" run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#232 — Bump faraday from 2.14.2 to 2.14.3"
+  assert_contains "$output_content" "Risk: :large_green_circle: low-risk"
+}
+
+@test "parses squash merge commit titles to fetch the pull request by number" {
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" != "api" ]]; then
+  exit 1
+fi
+
+case "$2" in
+  repos/trade-tariff/example/commits/squash-sha)
+    printf '%s\n' 'Add new deployment signal (#789)'
+    ;;
+  repos/trade-tariff/example/pulls/789)
+    printf '%s\n' '{"number":789,"title":"Add new deployment signal","html_url":"https://github.com/trade-tariff/example/pull/789","labels":[]}'
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/gh"
+
+  SHA="squash-sha" run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#789 — Add new deployment signal"
+}
+
+@test "falls back to the associated pull request endpoint for non-merge commits" {
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" != "api" ]]; then
+  exit 1
+fi
+
+case "$2" in
+  repos/trade-tariff/example/commits/head-sha)
+    printf '%s\n' 'Feature branch commit'
+    ;;
+  repos/trade-tariff/example/commits/head-sha/pulls)
+    printf '%s\n' '{"number":321,"title":"Associated branch PR","html_url":"https://github.com/trade-tariff/example/pull/321","labels":[]}'
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/gh"
+
+  SHA="head-sha" run_script
+
+  [ "$status" -eq 0 ]
+  output_content="$(cat "$GITHUB_OUTPUT")"
+  assert_contains "$output_content" "#321 — Associated branch PR"
 }
 
 @test "outputs PR title and link when a PR is found" {
@@ -112,6 +227,46 @@ run_script() {
   workflow="$repo_root/.github/workflows/deploy-ecs.yml"
 
   run grep -F "continue-on-error: true" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs pr-info step runs the shared script" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "run: .trade-tariff-tools/scripts/deploy-pr-info.sh" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs checks out the reusable workflow source for the shared pr-info script" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "JOB_CONTEXT: \${{ toJson(job) }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "repository: \${{ steps.workflow-source.outputs.repository }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "ref: \${{ steps.workflow-source.outputs.sha }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "path: .trade-tariff-tools" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs sends caller repository and triggering sha to pr-info" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "REPO: \${{ github.repository }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "TRIGGER_SHA: \${{ github.event.workflow_run.head_sha || github.event.pull_request.merge_commit_sha || github.event.pull_request.head.sha || github.sha }}" "$workflow"
+  [ "$status" -eq 0 ]
+}
+
+@test "deploy-ecs checks out the workflow_run head sha when production follows staging" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "ACTUAL_REF=\"\${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}\"" "$workflow"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## What

- Move deploy PR notification lookup into `scripts/deploy-pr-info.sh`.
- Prefer the triggering PR/commit before falling back to the deployed app commit.
- Parse merge commit titles like `Merge pull request #123 ...` and squash titles like `Change title (#123)` before using the associated PR endpoint.
- Update `deploy-ecs.yml` so production `workflow_run` deploys use `workflow_run.head_sha` and the notify job runs the shared script from a checkout of `trade-tariff-tools`.
- Add Bats coverage for the deploy-title edge cases and CI path-filter coverage for the new script/workflow contract.

## Why

Slack deploy notifications could show a stale deployment PR title when the workflow looked up pull requests from the deployed commit/ref rather than the PR or commit that triggered the deployment.