### PR TITLE
HMRC-2408 Add shared Debride action

### DIFF
--- a/.github/actions/debride/action.yml
+++ b/.github/actions/debride/action.yml
@@ -1,0 +1,43 @@
+name: Debride
+description: Run Debride and fail when normalized findings are not in the repo baseline.
+
+inputs:
+  baseline-path:
+    description: Path to the normalized Debride baseline file.
+    required: false
+    default: config/debride.whitelist
+  paths:
+    description: Newline-separated paths to scan. Defaults to existing app and lib paths.
+    required: false
+    default: ''
+  rails:
+    description: Run Debride with --rails.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        BASELINE_PATH: ${{ inputs.baseline-path }}
+        PATHS: ${{ inputs.paths }}
+        RAILS: ${{ inputs.rails }}
+      run: |
+        set -euo pipefail
+
+        args=(--baseline "$BASELINE_PATH")
+
+        if [[ "$RAILS" != "true" ]]; then
+          args+=(--no-rails)
+        fi
+
+        if [[ -n "$PATHS" ]]; then
+          args+=(--)
+          while IFS= read -r path || [[ -n "$path" ]]; do
+            [[ -z "$path" || "$path" == \#* ]] && continue
+            args+=("$path")
+          done <<< "$PATHS"
+        fi
+
+        "${{ github.action_path }}/debride-check" "${args[@]}"

--- a/.github/actions/debride/debride-check
+++ b/.github/actions/debride/debride-check
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: debride-check [--baseline PATH] [--no-rails] [--update-baseline] [-- PATH...]
+
+Runs Debride, normalizes findings to ClassOrModule#method, and compares them
+with a checked-in baseline. By default it scans the existing app and lib paths.
+EOF
+}
+
+baseline_file="config/debride.whitelist"
+rails=1
+update_baseline=0
+paths=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --baseline)
+      baseline_file="$2"
+      shift 2
+      ;;
+    --no-rails)
+      rails=0
+      shift
+      ;;
+    --update-baseline)
+      update_baseline=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      paths=("$@")
+      break
+      ;;
+    *)
+      paths+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if ((${#paths[@]} == 0)); then
+  for path in app lib; do
+    [[ -e "$path" ]] && paths+=("$path")
+  done
+fi
+
+if ((${#paths[@]} == 0)); then
+  echo "::error::No Debride scan paths were provided and neither app nor lib exists." >&2
+  exit 2
+fi
+
+normalize_findings() {
+  ruby -e '
+    current_class = nil
+
+    ARGF.each_line do |line|
+      chomped = line.chomp
+      stripped = chomped.strip
+
+      if chomped == stripped && stripped != "" && stripped != "These methods MIGHT not be called:" && !stripped.start_with?("Total suspect LOC:")
+        current_class = stripped
+      elsif current_class && line =~ /\A\s{2}([A-Za-z_][A-Za-z0-9_!?=]*)\s+/
+        puts "#{current_class}##{Regexp.last_match(1)}"
+      end
+    end
+  ' | sort -u
+}
+
+if [[ -n "${DEBRIDE_OUTPUT_FILE:-}" ]]; then
+  raw_output="$(cat "$DEBRIDE_OUTPUT_FILE")"
+else
+  command=(bundle exec debride)
+  if ((rails)); then
+    command+=(--rails)
+  fi
+  command+=("${paths[@]}")
+
+  raw_output="$("${command[@]}")"
+fi
+
+findings_tmp="$(mktemp)"
+baseline_tmp="$(mktemp)"
+trap 'rm -f "$findings_tmp" "$baseline_tmp"' EXIT
+
+printf '%s\n' "$raw_output" | normalize_findings > "$findings_tmp"
+
+if ((update_baseline)); then
+  mkdir -p "$(dirname "$baseline_file")"
+  {
+    printf '%s\n' "# Debride cannot see framework convention calls reliably."
+    printf '%s\n' "# This normalized baseline is compared by trade-tariff-tools/debride."
+    printf '\n'
+    cat "$findings_tmp"
+  } > "$baseline_file"
+  echo "Updated Debride baseline at $baseline_file"
+  exit 0
+fi
+
+if [[ ! -f "$baseline_file" ]]; then
+  echo "::error::Missing Debride baseline: $baseline_file" >&2
+  echo "Run with --update-baseline to create it." >&2
+  exit 2
+fi
+
+grep -vE '^\s*(#|$)' "$baseline_file" | sort -u > "$baseline_tmp" || true
+
+unexpected="$(comm -13 "$baseline_tmp" "$findings_tmp")"
+
+if [[ -n "$unexpected" ]]; then
+  echo "Debride reported methods not in $baseline_file:"
+  printf '%s\n' "$unexpected"
+  exit 1
+fi
+
+echo "Debride findings match $baseline_file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ on:
       - 'bin/rotate-task-definitions'
       - '.github/actions/auto-merge-low-risk/**'
       - '.github/actions/check-pr-lines/**'
+      - '.github/actions/debride/**'
       - '.github/workflows/auto-merge-low-risk.yml'
+      - '.pre-commit-hooks.yaml'
       - 'scripts/deploy-pr-info.sh'
       - 'scripts/trufflehog-pre-commit.sh'
       - 'tests/**'
@@ -33,7 +35,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
+        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/debride/debride-check .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: debride
+  name: debride
+  description: Run Debride and fail when normalized findings are not in the repo baseline.
+  entry: .github/actions/debride/debride-check
+  language: script
+  pass_filenames: false
+  stages: [pre-push]

--- a/tests/debride.bats
+++ b/tests/debride.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  repo="$(mktemp -d)"
+  script="${BATS_TEST_DIRNAME}/../.github/actions/debride/debride-check"
+  [[ -f "$script" ]] || fail "missing ${script}"
+
+  mkdir -p "$repo/app" "$repo/config"
+  raw_output="$repo/debride-output.txt"
+}
+
+teardown() {
+  rm -rf "$repo"
+}
+
+write_debride_output() {
+  cat > "$raw_output" <<'EOF'
+These methods MIGHT not be called:
+
+ApplicationController
+  skip_time_machine                   app/controllers/application_controller.rb:12-14 (3)
+
+TariffSynchronizer::Mailer
+  file_write_error                    app/mailers/tariff_synchronizer/mailer.rb:20-22 (3)
+EOF
+}
+
+@test "passes when normalized findings match the baseline" {
+  write_debride_output
+  cat > "$repo/config/debride.whitelist" <<'EOF'
+# Existing framework-driven findings
+
+ApplicationController#skip_time_machine
+TariffSynchronizer::Mailer#file_write_error
+EOF
+
+  cd "$repo" || return 1
+  run env DEBRIDE_OUTPUT_FILE="$raw_output" bash "$script" --baseline config/debride.whitelist -- app
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Debride findings match config/debride.whitelist"
+}
+
+@test "fails when Debride reports a finding outside the baseline" {
+  write_debride_output
+  cat > "$repo/config/debride.whitelist" <<'EOF'
+ApplicationController#skip_time_machine
+EOF
+
+  cd "$repo" || return 1
+  run env DEBRIDE_OUTPUT_FILE="$raw_output" bash "$script" --baseline config/debride.whitelist -- app
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Debride reported methods not in config/debride.whitelist"
+  assert_contains "$output" "TariffSynchronizer::Mailer#file_write_error"
+}
+
+@test "writes a normalized baseline" {
+  write_debride_output
+
+  cd "$repo" || return 1
+  run env DEBRIDE_OUTPUT_FILE="$raw_output" bash "$script" --baseline config/debride.whitelist --update-baseline -- app
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Updated Debride baseline at config/debride.whitelist"
+  assert_contains "$(cat "$repo/config/debride.whitelist")" "ApplicationController#skip_time_machine"
+  assert_contains "$(cat "$repo/config/debride.whitelist")" "TariffSynchronizer::Mailer#file_write_error"
+}
+
+@test "handles Debride findings reported under main" {
+  cat > "$raw_output" <<'EOF'
+These methods MIGHT not be called:
+
+main
+  graphviz                            config.rb:53-66 (14)
+
+Total suspect LOC: 14
+EOF
+
+  cd "$repo" || return 1
+  run env DEBRIDE_OUTPUT_FILE="$raw_output" bash "$script" --baseline config/debride.whitelist --update-baseline -- config.rb
+
+  [ "$status" -eq 0 ]
+  assert_contains "$(cat "$repo/config/debride.whitelist")" "main#graphviz"
+}
+
+@test "fails clearly when the baseline is missing" {
+  write_debride_output
+
+  cd "$repo" || return 1
+  run env DEBRIDE_OUTPUT_FILE="$raw_output" bash "$script" --baseline config/debride.whitelist -- app
+
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "Missing Debride baseline: config/debride.whitelist"
+}


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HMRC-2408

### What?

I have added/removed/altered:

- [x] Added a shared Debride composite action under `.github/actions/debride`
- [x] Added a matching exported pre-commit hook in `.pre-commit-hooks.yaml`
- [x] Added Bats coverage for baseline matching, unexpected findings, baseline generation, missing baselines, and non-Rails `main#method` findings
- [x] Updated tools CI path filters and bash syntax checks for the new action

### Why?

I am doing this because:

- Multiple Trade Tariff Ruby repos should be able to run the same Debride baseline logic
- CI can consume the shared GitHub Action instead of duplicating implementation details
- Non-Nix pre-commit users can consume the same script through the exported hook
