### PR TITLE
fix: keep newest ECS task definition revisions

### DIFF
--- a/bin/rotate-task-definitions
+++ b/bin/rotate-task-definitions
@@ -69,7 +69,7 @@ deregister_unused() {
         echo "Processing family: $family"
 
         local revisions
-        revisions=($(list_exact_active_task_definition_revisions "$family"))
+        mapfile -t revisions < <(list_exact_active_task_definition_revisions "$family" | sort -t ':' -k 7,7nr)
 
         if [ ${#revisions[@]} -eq 0 ]; then
              echo "  [SKIP] No active revisions found."

--- a/tests/rotate-revisions.bats
+++ b/tests/rotate-revisions.bats
@@ -41,6 +41,9 @@ case "$1" in
       admin-job)
         printf '%s\n' "arn:aws:ecs:eu-west-2:123456789012:task-definition/admin-job:7"
         ;;
+      frontend)
+        printf '%s\n' "arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1049 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1050 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1051 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1052 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1061 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1062 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1063 arn:aws:ecs:eu-west-2:123456789012:task-definition/frontend:1064"
+        ;;
       *)
         printf '\n'
         ;;
@@ -91,4 +94,22 @@ teardown() {
   [ "$status" -eq 0 ]
   deregistered="$(cat "$capture/deregistered.txt")"
   assert_contains "$deregistered" "task-definition/admin-job:7"
+}
+
+@test "rotating a family keeps the numerically newest revisions when AWS returns older revisions first" {
+  capture="$tmpdir/capture-ordering"
+  mkdir -p "$capture"
+
+  run env TEST_CAPTURE_DIR="$capture" TEST_FAMILIES="frontend" "$repo_root/bin/rotate-task-definitions" 4
+
+  [ "$status" -eq 0 ]
+  deregistered="$(cat "$capture/deregistered.txt")"
+  assert_contains "$deregistered" "task-definition/frontend:1049"
+  assert_contains "$deregistered" "task-definition/frontend:1050"
+  assert_contains "$deregistered" "task-definition/frontend:1051"
+  assert_contains "$deregistered" "task-definition/frontend:1052"
+  assert_not_contains "$deregistered" "task-definition/frontend:1061"
+  assert_not_contains "$deregistered" "task-definition/frontend:1062"
+  assert_not_contains "$deregistered" "task-definition/frontend:1063"
+  assert_not_contains "$deregistered" "task-definition/frontend:1064"
 }


### PR DESCRIPTION
### Jira link

Issue: No ticket/issue

### What?

I have altered:

- [x] Sort exact active ECS task definition revisions by numeric revision descending before applying `keep-latest`
- [x] Add a Bats regression for AWS returning older revisions first

### Why?

The rotation command trusted AWS return order when deciding which revisions were the latest. In the observed production run, older revisions were kept while newer inactive revisions were deregistered.

Sorting by the final ARN field, the task definition revision, makes `keep-latest` preserve the newest numeric revisions regardless of AWS response order. Revisions currently in use are still preserved independently.