### PR TITLE
Accept waf_bypass_token secret in e2e test workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -52,6 +52,9 @@ on:
       spimm_api_key:
         description: 'Green Lanes SPIMM API key'
         required: false
+      waf_bypass_token:
+        description: 'Secret token sent in X-WAF-Bypass header to bypass WAF bot control'
+        required: false
 
 jobs:
   test:
@@ -92,6 +95,8 @@ jobs:
             fi
             echo "BASIC_PASSWORD=${{ secrets.basic_password }}"
             echo "SPIMM_API_KEY=${{ secrets.spimm_api_key }}"
+            echo "WAF_BYPASS_TOKEN=${{ secrets.waf_bypass_token }}"
+
             echo "PLAYWRIGHT_ENV=${{ inputs.test-environment }}"
             echo "CI=true"
             echo "ROLE_TO_ASSUME=arn:aws:iam::${ACCOUNT_ID}:role/GithubActions-E2E-Testing-Role"


### PR DESCRIPTION
### Jira link

OTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added `waf_bypass_token` as an accepted secret in the shared e2e test workflow
- [x] Exported it as `WAF_BYPASS_TOKEN` env var so Playwright can send it in the `X-WAF-Bypass` header

### Why?

I am doing this because:

- The WAF Bot Control rule on production blocks Playwright (headless Chromium) as a bot, causing 12 e2e tests to time out
- A companion PR in `trade-tariff-platform-aws-terraform` adds a WAF allow rule that matches the `X-WAF-Bypass` header and terminates evaluation before bot control runs
- A companion PR in `trade-tariff-e2e-tests` adds the Playwright header config and wires the secret into the production check workflow
- This workflow change is the glue that passes the secret from GitHub Actions into the test run

Companion PRs:
- trade-tariff-platform-aws-terraform#641 — WAF allow rule and variable
- trade-tariff-e2e-tests#93 — Playwright sends the header, production workflow passes the secret

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages