### PR TITLE
Pass WAF e2e secret through multi ECS workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/workflows/close-stale-pull-requests-reusable.yml'
       - '.github/workflows/deploy-ecs.yml'
+      - '.github/workflows/deploy-multi-ecs.yml'
       - '.github/actions/db-migrate/**'
       - 'bin/cleanup-ecs-families'
       - 'bin/run-task'

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -58,6 +58,9 @@ on:
       admin_bypass_password:
         description: 'Password for admin bypass'
         required: false
+      waf_bypass_token:
+        description: 'Secret token sent in X-WAF-Bypass header to bypass WAF bot control'
+        required: false
 
 permissions:
   contents: read
@@ -194,6 +197,7 @@ jobs:
       test-environment: ${{ inputs.environment }}
     secrets:
       basic_password: ${{ secrets.basic-password }}
+      waf_bypass_token: ${{ secrets.waf_bypass_token }}
 
   e2e-test-fpo:
     if: ${{ inputs.test-flavour == 'fpo' }}

--- a/.github/workflows/deploy-multi-ecs.yml
+++ b/.github/workflows/deploy-multi-ecs.yml
@@ -32,6 +32,9 @@ on:
         required: false
       admin_bypass_password:
         required: false
+      waf_bypass_token:
+        description: 'Secret token sent in X-WAF-Bypass header to bypass WAF bot control'
+        required: false
 
 jobs:
   start-all:
@@ -78,6 +81,7 @@ jobs:
       test-environment: ${{ inputs.environment }}
     secrets:
       basic_password: ${{ secrets.basic-password }}
+      waf_bypass_token: ${{ secrets.waf_bypass_token }}
 
   e2e-test-fpo:
     if: ${{ inputs.test-flavour == 'fpo' }}

--- a/tests/db-migrate-action.bats
+++ b/tests/db-migrate-action.bats
@@ -58,3 +58,13 @@ load test_helper
   run grep -F "migrate: \${{ inputs.migrate && toJson(matrix.app.migrate) == 'true' }}" "$workflow"
   [ "$status" -eq 0 ]
 }
+
+@test "deploy-multi-ecs passes the WAF bypass token to tariff e2e tests" {
+  workflow="$repo_root/.github/workflows/deploy-multi-ecs.yml"
+
+  run grep -F "waf_bypass_token:" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "waf_bypass_token: \${{ secrets.waf_bypass_token }}" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What changed

- Added the optional `waf_bypass_token` secret to the reusable `deploy-multi-ecs.yml` workflow.
- Added the optional `waf_bypass_token` secret to the reusable `deploy-ecs.yml` workflow.
- Passed that secret through to the tariff e2e reusable workflow from both deployment workflows.
- Added a Bats contract test for the multi-ECS WAF secret wiring.
- Added `deploy-multi-ecs.yml` to the CI path filter so workflow contract changes run CI.

## Why

Deployment workflows run tariff e2e tests through reusable workflows. Called workflows cannot fetch the organisation secret by themselves, so callers need to pass the secret and the reusable deployment workflows need to forward it.

## Risk

Low risk: this only adds optional reusable workflow secret plumbing for e2e test traffic.