### PR TITLE
fix: guard against null author login in Copilot review gate

### DIFF
--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -69,7 +69,7 @@ COPILOT_REVIEW_JQ='[
       .author.login == "copilot"
       or .author.login == "copilot-pull-request-reviewer"
       or .author.login == "github-copilot[bot]"
-      or (.author.login | test("copilot"; "i"))
+      or ((.author.login // "") | test("copilot"; "i"))
     )
 ] | length'
 
@@ -169,7 +169,7 @@ unresolved="$(jq -s '
     . == "copilot"
     or . == "copilot-pull-request-reviewer"
     or . == "github-copilot[bot]"
-    or test("copilot"; "i");
+    or ((. // "") | test("copilot"; "i"));
   [
     .[]
     | select(.isResolved == false)


### PR DESCRIPTION
### Jira link

No ticket/issue

### What?

I have added/removed/altered:

- [x] Fixed `check-copilot-review-gate.sh` to handle null `.author.login` values in jq expressions

### Why?

jq's `test/2` function errors with `"test("copilot"; "i") cannot be applied to: null"` when `.author.login` is null (e.g. a deleted or bot account with no login). This caused the auto-merge gate to fail hard rather than silently treating the null login as non-Copilot.

The fix coerces null to an empty string with `// ""` before calling `test` at both call sites — the initial review count filter and the unresolved-threads check.

### Have you? (optional)

- [x] Respected people's right not to receive lots of noisy messages