### PR TITLE
feat: add copilot-review-required input; fix jq null login bug

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -31,6 +31,13 @@ inputs:
       or unlabeled.
     required: false
     default: ''
+  copilot-review-required:
+    description: >-
+      When false, skip the Copilot review gate and merge immediately once all
+      other checks pass. Set to false for repos that do not have Copilot code
+      review enabled.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -71,7 +78,7 @@ runs:
           pending="$(gh pr view "$PR_NUMBER" \
             --repo "$repo" \
             --json reviewRequests \
-            -q '[.reviewRequests[]? | select(.login | test("copilot"; "i"))] | length')"
+            -q '[.reviewRequests[]? | select((.login // "") | test("copilot"; "i"))] | length')"
 
           if [[ "${pending:-0}" -gt 0 ]]; then
             echo "Copilot review already requested on PR #$PR_NUMBER."
@@ -115,20 +122,24 @@ runs:
           exit 0
         fi
 
-        set +e
-        "$gate_script" --repo "$repo" --pr "$PR_NUMBER"
-        gate_status=$?
-        set -e
+        if [[ "${{ inputs.copilot-review-required }}" == "true" ]]; then
+          set +e
+          "$gate_script" --repo "$repo" --pr "$PR_NUMBER"
+          gate_status=$?
+          set -e
 
-        if [[ "$gate_status" -eq 2 ]]; then
-          request_copilot_review
-          echo "Waiting for Copilot to review PR #$PR_NUMBER; auto-merge will be retried on the next workflow run."
-          exit 0
-        fi
+          if [[ "$gate_status" -eq 2 ]]; then
+            request_copilot_review
+            echo "Waiting for Copilot to review PR #$PR_NUMBER; auto-merge will be retried on the next workflow run."
+            exit 0
+          fi
 
-        if [[ "$gate_status" -ne 0 ]]; then
-          echo "Copilot review requirements not met for PR #$PR_NUMBER; skipping auto-merge."
-          exit 0
+          if [[ "$gate_status" -ne 0 ]]; then
+            echo "Copilot review requirements not met for PR #$PR_NUMBER; skipping auto-merge."
+            exit 0
+          fi
+        else
+          echo "Copilot review gate disabled for PR #$PR_NUMBER; proceeding to merge."
         fi
         
         gh pr review "$PR_NUMBER" \

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -14,6 +14,14 @@ on:
         type: string
         required: false
         default: merge
+      copilot-review-required:
+        description: >-
+          When false, skip the Copilot review gate and merge immediately once
+          all other checks pass. Set to false for repos that do not have
+          Copilot code review enabled.
+        type: boolean
+        required: false
+        default: false
 
     secrets:
       github-token:
@@ -72,6 +80,7 @@ jobs:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}
           merge-method: ${{ inputs.merge-method }}
+          copilot-review-required: ${{ inputs.copilot-review-required }}
           github-token: ${{ secrets.github-token }}
           pull-request-event-action: ${{ github.event.action }}
           pull-request-event-label: ${{ github.event.label.name }}


### PR DESCRIPTION
## Summary

- Adds a `copilot-review-required` boolean input (default: `false`) to the reusable workflow and composite action. When `false`, the Copilot review gate is skipped and auto-merge proceeds once all other checks pass — fixing the issue where repos without Copilot code review configured would have their auto-merge permanently blocked.
- Fixes a jq null-pointer crash in `request_copilot_review`: `.login` can be `null` on some review request objects, causing `test("copilot"; "i")` to fail with `cannot be applied to: null`. Added `// ""` guard to handle it safely.

## Consumer repos

Repos without Copilot configured should add `copilot-review-required: false` to their workflow call:

```yaml
uses: trade-tariff/trade-tariff-tools/.github/workflows/auto-merge-low-risk.yml@main
with:
  label: low-risk
  merge-method: merge
  copilot-review-required: false
```

## Test plan

- [ ] Verify auto-merge fires on a low-risk PR in a repo passing `copilot-review-required: false`
- [ ] Verify Copilot gate still blocks in a repo that opts in with `copilot-review-required: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)