### PR TITLE
feat: run scheduled ECS jobs non-interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,29 @@ Interactive script to execute commands in AWS ECS tasks. Uses `fzf` for interact
 
 # Run a rake task
 ./bin/ecs 'bundle exec rake tariff:jobs'
+
+# Select and run a scheduled job from the current AWS account
+./bin/ecs run
+
+# Run a scheduled job by name from the current AWS account
+./bin/ecs run backend-database-replication
+
+# Run the replication job without prompts and without tailing logs
+./bin/ecs run --yes --no-tail backend-database-replication
+
+# Filter explicitly if a job name exists in more than one environment in the account
+./bin/ecs run --environment staging --yes --no-tail backend-database-replication
 ```
+
+`ecs run` discovers scheduled jobs from the AWS account represented by your
+current credentials. Use `--environment` only as a filter when that account has
+more than one matching environment.
 
 **Features:**
 - Interactive selection of clusters, services, and tasks using `fzf`
+- Starts scheduled EventBridge-backed ECS jobs on demand with `ecs run`
+- Discovers scheduled jobs from the current AWS account credentials
+- Resolves the latest active task definition before starting scheduled jobs
 - Automatically starts `backend-job` tasks if none are running
 - Automatically stops `backend-job` tasks when you exit
 - Sets `RAILS_LOG_LEVEL=debug` for all commands

--- a/bin/ecs
+++ b/bin/ecs
@@ -7,7 +7,7 @@ set -o pipefail
 set -o noclobber
 
 readonly SCRIPT_NAME="$(basename "$0")"
-readonly REGION="eu-west-2"
+REGION="${AWS_REGION:-eu-west-2}"
 readonly MAX_WAIT_TIME=60
 
 print_usage() {
@@ -59,16 +59,24 @@ error_exit() {
     exit "${2:-1}"
 }
 
-check_dependencies() {
+check_core_dependencies() {
     local missing_deps=()
 
     command -v aws >/dev/null || missing_deps+=("aws")
     command -v jq >/dev/null || missing_deps+=("jq")
-    command -v fzf >/dev/null || missing_deps+=("fzf")
 
     if [[ ${#missing_deps[@]} -gt 0 ]]; then
         error_exit "Missing required dependencies: ${missing_deps[*]}"
     fi
+}
+
+check_fzf_dependency() {
+    command -v fzf >/dev/null || error_exit "Missing required dependency: fzf"
+}
+
+check_dependencies() {
+    check_core_dependencies
+    check_fzf_dependency
 }
 
 check_aws_credentials() {
@@ -417,54 +425,127 @@ and dispatches them as ECS tasks.
 OPTIONS:
     -h, --help      Show this help message and exit
     -r, --region    AWS region (default: $REGION)
+    -e, --environment
+                    Environment to run in (development, staging, production)
+    -y, --yes       Skip the confirmation prompt
     --no-tail       Start the task and exit without tailing logs
+
+ARGUMENTS:
+    JOB             Scheduled job name, for example backend-database-replication
 
 EXAMPLES:
     $SCRIPT_NAME run                    # Select and run a scheduled job
+    $SCRIPT_NAME run backend-database-replication
+    $SCRIPT_NAME run -e staging backend-database-replication
     $SCRIPT_NAME run --no-tail          # Start a job without tailing logs
 EOF
 }
 
-discover_eventbridge_jobs() {
-    local environment="$1"
-    local cluster="$2"
+rule_environment() {
+    local rule_name="$1"
+
+    case "$rule_name" in
+        *-development) echo "development" ;;
+        *-staging) echo "staging" ;;
+        *-production) echo "production" ;;
+        *) return 1 ;;
+    esac
+}
+
+discover_account_eventbridge_jobs() {
+    local requested_job="$1"
+    local environment_filter="$2"
+
+    local list_rules_args=(aws events list-rules --region "$REGION")
+    if [[ -n "$requested_job" ]]; then
+        list_rules_args+=(--name-prefix "${requested_job}-")
+    fi
 
     local rules
-    rules=$(aws events list-rules --region "$REGION" \
-        | jq -r --arg env "$environment" \
-            '.Rules[] | select(.Name | endswith("-" + $env)) | .Name')
-
-    [[ -n "$rules" ]] || error_exit "No EventBridge rules found for environment: $environment"
+    rules=$("${list_rules_args[@]}" | jq -r '.Rules[] | .Name')
 
     local results=""
 
     while IFS= read -r rule_name; do
-        local targets
-        targets=$(aws events list-targets-by-rule --rule "$rule_name" --region "$REGION")
+        [[ -n "$rule_name" ]] || continue
 
-        # Filter targets that reference the selected cluster
-        local matching
-        matching=$(echo "$targets" | jq -r --arg cluster "$cluster" \
-            '.Targets[] | select(.Arn | contains($cluster))')
+        local environment
+        environment=$(rule_environment "$rule_name") || continue
 
-        [[ -n "$matching" ]] || continue
-
-        local command
-        command=$(echo "$matching" | jq -r \
-            '.Input | fromjson | .containerOverrides[0].command | join(" ")')
+        if [[ -n "$environment_filter" && "$environment" != "$environment_filter" ]]; then
+            continue
+        fi
 
         local display_name
         display_name="${rule_name%-"$environment"}"
 
-        if [[ -n "$results" ]]; then
-            results+=$'\n'
+        if [[ -n "$requested_job" && "$display_name" != "$requested_job" ]]; then
+            continue
         fi
-        results+="${display_name}"$'\t'"${command}"
+
+        local targets
+        targets=$(aws events list-targets-by-rule --rule "$rule_name" --region "$REGION")
+
+        local matching
+        matching=$(echo "$targets" | jq -c '.Targets[] | select(.EcsParameters.TaskDefinitionArn != null)')
+        [[ -n "$matching" ]] || continue
+
+        while IFS= read -r target; do
+            [[ -n "$target" ]] || continue
+
+            local command cluster
+            command=$(echo "$target" | jq -r '.Input | fromjson | .containerOverrides[0].command | join(" ")')
+            cluster=$(echo "$target" | jq -r '.Arn | split("/") | .[-1]')
+
+            if [[ -n "$results" ]]; then
+                results+=$'\n'
+            fi
+            results+="${display_name}"$'\t'"${command}"$'\t'"${environment}"$'\t'"${cluster}"
+        done <<< "$matching"
     done <<< "$rules"
 
-    [[ -n "$results" ]] || error_exit "No ECS jobs found for cluster: $cluster"
-
     echo "$results"
+}
+
+latest_active_task_definition() {
+    local task_def_arn="$1"
+    local family_revision="${task_def_arn##*/}"
+    local family="${family_revision%:*}"
+
+    local latest
+    latest=$(aws ecs describe-task-definition \
+        --task-definition "$family" \
+        --region "$REGION" \
+        | jq -r '.taskDefinition.taskDefinitionArn // empty')
+
+    [[ -n "$latest" ]] || error_exit "Could not find active task definition for family: $family"
+
+    echo "$latest"
+}
+
+eventbridge_target_for_rule() {
+    local rule_name="$1"
+    local cluster="$2"
+
+    local targets
+    targets=$(aws events list-targets-by-rule --rule "$rule_name" --region "$REGION")
+
+    local matching
+    matching=$(echo "$targets" | jq -c --arg cluster "$cluster" \
+        '[.Targets[] | select(.EcsParameters.TaskDefinitionArn != null and (.Arn | split("/") | .[-1]) == $cluster)]')
+
+    local count
+    count=$(echo "$matching" | jq -r 'length')
+
+    if [[ "$count" -ne 1 ]]; then
+        echo "Expected exactly one ECS target for $rule_name in $cluster, found $count" >&2
+        if [[ "$count" -gt 0 ]]; then
+            echo "$matching" | jq -r '.[] | " - " + (.Id // "unknown-target") + " " + (.EcsParameters.TaskDefinitionArn // "unknown-task-definition")' >&2
+        fi
+        return 1
+    fi
+
+    echo "$matching" | jq -c '.[0]'
 }
 
 tail_task_logs() {
@@ -500,7 +581,7 @@ tail_task_logs() {
     local log_group="platform-logs-${environment}"
     local stream_prefix="ecs/${container}/${task_id}"
 
-    echo "Task is running. Tailing logs (Ctrl+C to detach)..." >&2
+    echo "Task status is $task_status. Tailing logs (Ctrl+C to detach)..." >&2
 
     local tail_pid=""
 
@@ -522,7 +603,7 @@ tail_task_logs() {
 
     aws logs tail "$log_group" \
         --log-stream-name-prefix "$stream_prefix" \
-        --since "1s" \
+        --since "5m" \
         --format short \
         --follow \
         --region "$REGION" &
@@ -530,28 +611,37 @@ tail_task_logs() {
 
     # Poll task status until stopped
     while true; do
-        sleep 15
+        sleep "${TASK_POLL_SECONDS:-15}"
         local status
         status=$(aws ecs describe-tasks --cluster "$cluster" --tasks "$task_arn" --region "$REGION" \
             | jq -r '.tasks[0].lastStatus')
 
         if [[ "$status" == "STOPPED" ]]; then
             # Wait for final logs to flush
-            sleep 10
+            sleep "${FINAL_LOG_FLUSH_SECONDS:-10}"
             cleanup_tail
 
-            local exit_code
-            exit_code=$(aws ecs describe-tasks --cluster "$cluster" --tasks "$task_arn" --region "$REGION" \
-                | jq -r '.tasks[0].containers[0].exitCode // "unknown"')
+            local stopped
+            stopped=$(aws ecs describe-tasks --cluster "$cluster" --tasks "$task_arn" --region "$REGION")
+
+            local exit_code stopped_reason container_reason
+            exit_code=$(echo "$stopped" | jq -r --arg container "$container" '.tasks[0].containers[] | select(.name == $container) | .exitCode // "unknown"')
+            stopped_reason=$(echo "$stopped" | jq -r '.tasks[0].stoppedReason // empty')
+            container_reason=$(echo "$stopped" | jq -r --arg container "$container" '.tasks[0].containers[] | select(.name == $container) | .reason // empty')
 
             if [[ "$exit_code" == "0" ]]; then
                 echo "Task completed successfully (exit code: 0)" >&2
+                trap - INT
+                return 0
             else
                 echo "Task failed (exit code: $exit_code)" >&2
+                [[ -n "$stopped_reason" ]] && echo "Stopped reason: $stopped_reason" >&2
+                [[ -n "$container_reason" ]] && echo "Container reason: $container_reason" >&2
             fi
 
             trap - INT
-            return
+            [[ "$exit_code" =~ ^[0-9]+$ && "$exit_code" -gt 0 && "$exit_code" -le 255 ]] && return "$exit_code"
+            return 1
         fi
     done
 }
@@ -559,6 +649,9 @@ tail_task_logs() {
 run_main() {
     local region="$REGION"
     local tail=true
+    local environment=""
+    local assume_yes=false
+    local requested_job=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -571,6 +664,15 @@ run_main() {
                 region="$2"
                 shift 2
                 ;;
+            -e|--environment)
+                [[ -n "${2:-}" ]] || error_exit "--environment requires a value"
+                environment="$2"
+                shift 2
+                ;;
+            -y|--yes)
+                assume_yes=true
+                shift
+                ;;
             --no-tail)
                 tail=false
                 shift
@@ -579,52 +681,109 @@ run_main() {
                 error_exit "Unknown option: $1. See '$SCRIPT_NAME run --help'"
                 ;;
             *)
-                error_exit "Unexpected argument: $1. See '$SCRIPT_NAME run --help'"
+                [[ -z "$requested_job" ]] || error_exit "Too many arguments. See '$SCRIPT_NAME run --help'"
+                requested_job="$1"
+                shift
                 ;;
         esac
     done
 
-    check_dependencies
+    REGION="$region"
+
+    check_core_dependencies
     check_aws_credentials
 
-    local cluster
-    cluster=$(select_cluster)
+    local cluster=""
+    local jobs=""
+    local selected=""
+    local target=""
 
-    local environment
-    environment="${cluster##*-}"
+    if [[ -n "$environment" ]]; then
+        case "$environment" in
+            development|staging|production) ;;
+            *) error_exit "Unknown environment: $environment" ;;
+        esac
+    fi
 
     echo "Discovering scheduled jobs..." >&2
 
-    local jobs
-    jobs=$(discover_eventbridge_jobs "$environment" "$cluster")
+    jobs=$(discover_account_eventbridge_jobs "$requested_job" "$environment")
+    if [[ -z "$jobs" ]]; then
+        if [[ -n "$requested_job" ]]; then
+            if [[ -n "$environment" ]]; then
+                local available_jobs
+                available_jobs=$(discover_account_eventbridge_jobs "" "$environment")
+                if [[ -n "$available_jobs" ]]; then
+                    echo "Available jobs:" >&2
+                    echo "$available_jobs" | cut -f1 | sort -u >&2
+                fi
+                error_exit "No ECS job named '$requested_job' found in $environment"
+            fi
 
-    local selected
-    selected=$(echo "$jobs" | column -t -s $'\t' \
-        | fzf --height 40% --prompt "Select a Job: " --no-info)
+            error_exit "No ECS job named '$requested_job' found"
+        fi
+
+        error_exit "No scheduled ECS jobs found"
+    fi
+
+    if [[ -n "$requested_job" ]]; then
+        local match_count
+        match_count=$(echo "$jobs" | cut -f3,4 | sort -u | wc -l | tr -d ' ')
+        if [[ "$match_count" -gt 1 ]]; then
+            echo "Multiple ECS jobs named '$requested_job' found:" >&2
+            echo "$jobs" | awk -F '\t' '{ print $1 " (" $3 ")" }' | sort -u >&2
+            error_exit "Specify --environment to choose one"
+        fi
+
+        selected=$(echo "$jobs" | head -n 1)
+    elif [[ -z "$selected" ]]; then
+        check_fzf_dependency
+        selected=$(echo "$jobs" \
+            | fzf --height 40% --prompt "Select a Job: " --no-info --delimiter $'\t' --with-nth 1,3,2)
+    fi
 
     [[ -n "$selected" ]] || error_exit "No job selected"
 
     local job_name
-    job_name=$(echo "$selected" | awk '{print $1}')
+    job_name=$(echo "$selected" | cut -f1)
+    environment=$(echo "$selected" | cut -f3)
+    cluster=$(echo "$selected" | cut -f4)
+    [[ -n "$environment" ]] || error_exit "Could not determine environment for selected job"
+    [[ -n "$cluster" ]] || error_exit "Could not determine cluster for selected job"
 
     # Look up the full details from the original jobs list
     local rule_name="${job_name}-${environment}"
 
-    local targets
-    targets=$(aws events list-targets-by-rule --rule "$rule_name" --region "$REGION")
+    target=$(eventbridge_target_for_rule "$rule_name" "$cluster")
 
-    local target
-    target=$(echo "$targets" | jq -r --arg cluster "$cluster" \
-        '.Targets[] | select(.Arn | contains($cluster))')
+    local event_task_def_arn task_def_arn overrides container command
+    event_task_def_arn=$(echo "$target" | jq -r '.EcsParameters.TaskDefinitionArn // empty')
+    [[ -n "$event_task_def_arn" ]] || error_exit "EventBridge target for $rule_name does not include a task definition"
 
-    local task_def_arn overrides
-    task_def_arn=$(echo "$target" | jq -r '.EcsParameters.TaskDefinitionArn')
+    task_def_arn=$(latest_active_task_definition "$event_task_def_arn")
     overrides=$(echo "$target" | jq -r '.Input')
+    [[ -n "$overrides" && "$overrides" != "null" ]] || error_exit "EventBridge target for $rule_name does not include container overrides"
+
+    container=$(echo "$overrides" | jq -r '.containerOverrides[0].name // empty')
+    command=$(echo "$overrides" | jq -r '.containerOverrides[0].command // [] | join(" ")')
+    [[ -n "$container" ]] || error_exit "EventBridge target for $rule_name does not include a container name"
 
     echo "" >&2
-    echo "Run '$job_name' in $environment? [y/N] " >&2
-    read -r confirm
-    [[ "$confirm" =~ ^[Yy]$ ]] || exit 0
+    echo "Job: $job_name" >&2
+    echo "Environment: $environment" >&2
+    echo "Cluster: $cluster" >&2
+    echo "Container: $container" >&2
+    echo "Command: $command" >&2
+    echo "EventBridge task definition: $event_task_def_arn" >&2
+    echo "Latest active task definition: $task_def_arn" >&2
+    echo "Logs: platform-logs-${environment}/ecs/${container}/<task-id>" >&2
+    echo "Tail logs: $tail" >&2
+
+    if [[ "$assume_yes" == false ]]; then
+        echo "Run '$job_name' in $environment? [y/N] " >&2
+        read -r confirm
+        [[ "$confirm" =~ ^[Yy]$ ]] || exit 0
+    fi
 
     # Get network config
     local network_config
@@ -635,8 +794,8 @@ run_main() {
 
     echo "Starting task..." >&2
 
-    local task_arn
-    task_arn=$(aws ecs run-task \
+    local run_task_response
+    run_task_response=$(aws ecs run-task \
         --cluster "$cluster" \
         --task-definition "$task_def_arn" \
         --launch-type FARGATE \
@@ -644,9 +803,19 @@ run_main() {
         --network-configuration "awsvpcConfiguration={subnets=[$subnets],securityGroups=[$sg],assignPublicIp=DISABLED}" \
         --started-by ecs-run-script \
         --overrides "$overrides" \
-        | jq -r '.tasks[0].taskArn')
+    )
 
-    [[ -n "$task_arn" ]] || error_exit "Failed to start task"
+    local failure_count
+    failure_count=$(echo "$run_task_response" | jq -r '.failures | length')
+    if [[ "$failure_count" -gt 0 ]]; then
+        echo "Failed to start task:" >&2
+        echo "$run_task_response" | jq -r '.failures[] | " - " + (.arn // "unknown-arn") + " " + (.reason // "unknown-reason") + ": " + (.detail // "no detail")' >&2
+        return 1
+    fi
+
+    local task_arn
+    task_arn=$(echo "$run_task_response" | jq -r '.tasks[0].taskArn // empty')
+    [[ -n "$task_arn" ]] || error_exit "Failed to start task: AWS response did not include a task ARN"
 
     local task_id
     task_id=$(echo "$task_arn" | awk -F'/' '{print $NF}')
@@ -655,10 +824,6 @@ run_main() {
     if [[ "$tail" == false ]]; then
         return
     fi
-
-    # Derive container name from the overrides
-    local container
-    container=$(echo "$overrides" | jq -r '.containerOverrides[0].name')
 
     tail_task_logs "$cluster" "$task_arn" "$environment" "$container"
 }

--- a/tests/ecs-run.bats
+++ b/tests/ecs-run.bats
@@ -1,0 +1,384 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  setup_stub_path
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+write_common_stubs() {
+  local fzf_mode="${1:-fail-if-called}"
+
+  cat > "$stub_bin/aws" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$TEST_CAPTURE_DIR/aws-calls.txt"
+
+case "$1 $2" in
+  "sts get-caller-identity")
+    printf '{"Account":"451934005581"}'
+    ;;
+  "events list-rules")
+    if [[ "${TEST_INCLUDE_PRODUCTION_ONLY:-}" == "true" ]]; then
+      printf '{"Rules":[{"Name":"backend-database-replication-production"}]}'
+    elif [[ "${TEST_INCLUDE_DEVELOPMENT_REPLICATION:-}" == "true" ]]; then
+      printf '{"Rules":[{"Name":"backend-database-replication-development"},{"Name":"backend-database-replication-staging"},{"Name":"backend-database-backup-staging"}]}'
+    else
+      printf '{"Rules":[{"Name":"backend-database-replication-staging"},{"Name":"backend-database-backup-staging"}]}'
+    fi
+    ;;
+  "events list-targets-by-rule")
+    rule=""
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "--rule" ]]; then
+        rule="$2"
+        break
+      fi
+      shift
+    done
+
+    case "$rule" in
+      "backend-database-replication-staging")
+        if [[ "${TEST_MULTIPLE_STAGING_TARGETS:-}" == "true" ]]; then
+          cat <<'JSON'
+{"Targets":[{"Id":"target-a","Arn":"arn:aws:ecs:eu-west-2:451934005581:cluster/trade-tariff-cluster-staging","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/db-replicate\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1019"}},{"Id":"target-b","Arn":"arn:aws:ecs:eu-west-2:451934005581:cluster/trade-tariff-cluster-staging","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/other\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1019"}}]}
+JSON
+        else
+        cat <<'JSON'
+{"Targets":[{"Arn":"arn:aws:ecs:eu-west-2:451934005581:cluster/trade-tariff-cluster-staging","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/db-replicate\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1019"}}]}
+JSON
+        fi
+        ;;
+      "backend-database-backup-staging")
+        cat <<'JSON'
+{"Targets":[{"Arn":"arn:aws:ecs:eu-west-2:451934005581:cluster/trade-tariff-cluster-staging","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/backup-database\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1020"}}]}
+JSON
+        ;;
+      "backend-database-replication-development")
+        cat <<'JSON'
+{"Targets":[{"Arn":"arn:aws:ecs:eu-west-2:844815912454:cluster/trade-tariff-cluster-development","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/db-replicate\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:844815912454:task-definition/backend-job-844815912454:300"}}]}
+JSON
+        ;;
+      "backend-database-replication-production")
+        cat <<'JSON'
+{"Targets":[{"Arn":"arn:aws:ecs:eu-west-2:382373577178:cluster/trade-tariff-cluster-production","Input":"{\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/db-replicate\"]}]}","EcsParameters":{"TaskDefinitionArn":"arn:aws:ecs:eu-west-2:382373577178:task-definition/backend-job-382373577178:900"}}]}
+JSON
+        ;;
+      *)
+        printf '{"Targets":[]}'
+        ;;
+    esac
+    ;;
+  "ec2 describe-subnets")
+    printf 'subnet-1\tsubnet-2'
+    ;;
+  "ec2 describe-security-groups")
+    printf 'sg-123'
+    ;;
+  "ecs describe-task-definition")
+    task_definition=""
+    while [[ "$#" -gt 0 ]]; do
+      if [[ "$1" == "--task-definition" ]]; then
+        task_definition="$2"
+        break
+      fi
+      shift
+    done
+
+    case "$task_definition" in
+      "backend-job-451934005581")
+        printf '{"taskDefinition":{"taskDefinitionArn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1020"}}'
+        ;;
+      "backend-job-844815912454")
+        printf '{"taskDefinition":{"taskDefinitionArn":"arn:aws:ecs:eu-west-2:844815912454:task-definition/backend-job-844815912454:301"}}'
+        ;;
+      "backend-job-382373577178")
+        printf '{"taskDefinition":{"taskDefinitionArn":"arn:aws:ecs:eu-west-2:382373577178:task-definition/backend-job-382373577178:901"}}'
+        ;;
+      *)
+        echo "unexpected task definition family: $task_definition" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+  "ecs run-task")
+    printf '%s\n' "$*" > "$TEST_CAPTURE_DIR/run-task-args.txt"
+    if [[ "${TEST_RUN_TASK_FAILURE:-}" == "true" ]]; then
+      printf '{"tasks":[],"failures":[{"arn":"arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1020","reason":"CLIENT_EXCEPTION","detail":"TaskDefinition is inactive"}]}'
+    elif [[ "${TEST_RUN_TASK_NULL_ARN:-}" == "true" ]]; then
+      printf '{"tasks":[{"taskArn":null}],"failures":[]}'
+    else
+      printf '{"tasks":[{"taskArn":"arn:aws:ecs:eu-west-2:451934005581:task/trade-tariff-cluster-staging/task-123"}],"failures":[]}'
+    fi
+    ;;
+  "ecs describe-tasks")
+    exit_code="${TEST_TASK_EXIT_CODE:-0}"
+    printf '{"tasks":[{"lastStatus":"STOPPED","stoppedReason":"Essential container in task exited","containers":[{"name":"backend-job","exitCode":%s,"reason":"test reason"}]}]}' "$exit_code"
+    ;;
+  "logs tail")
+    printf '%s\n' "$*" > "$TEST_CAPTURE_DIR/logs-tail-args.txt"
+    ;;
+  *)
+    echo "unexpected aws command: $*" >&2
+    exit 1
+    ;;
+esac
+STUB
+  chmod +x "$stub_bin/aws"
+
+  case "$fzf_mode" in
+    none)
+      ;;
+    select-job)
+      cat > "$stub_bin/fzf" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+awk -F '\t' '$1 == "backend-database-replication" { print; exit }'
+STUB
+      chmod +x "$stub_bin/fzf"
+      ;;
+    fail-if-called)
+      cat > "$stub_bin/fzf" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "fzf should not be called for non-interactive ecs run" >&2
+exit 1
+STUB
+      chmod +x "$stub_bin/fzf"
+      ;;
+  esac
+}
+
+@test "ecs run detects scheduled jobs without selecting an ECS cluster first" {
+  write_common_stubs select-job
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --yes \
+    --no-tail
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Started task: task-123"
+
+  aws_calls="$(cat "$tmpdir/capture/aws-calls.txt")"
+  assert_not_contains "$aws_calls" "ecs list-clusters"
+  assert_contains "$(cat "$tmpdir/capture/run-task-args.txt")" "--cluster trade-tariff-cluster-staging"
+}
+
+@test "ecs run starts named scheduled job without interactive selection" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Started task: task-123"
+
+  run_task_args="$(cat "$tmpdir/capture/run-task-args.txt")"
+  assert_contains "$run_task_args" "--cluster trade-tariff-cluster-staging"
+  assert_contains "$run_task_args" "--task-definition arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1020"
+  assert_contains "$run_task_args" "awsvpcConfiguration={subnets=[subnet-1,subnet-2],securityGroups=[sg-123],assignPublicIp=DISABLED}"
+  assert_contains "$run_task_args" "--overrides {\"containerOverrides\":[{\"name\":\"backend-job\",\"command\":[\"/bin/sh\",\"-c\",\"./bin/db-replicate\"]}]}"
+}
+
+@test "ecs run detects environment for unique named scheduled job" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Started task: task-123"
+
+  run_task_args="$(cat "$tmpdir/capture/run-task-args.txt")"
+  assert_contains "$run_task_args" "--cluster trade-tariff-cluster-staging"
+  assert_contains "$run_task_args" "--task-definition arn:aws:ecs:eu-west-2:451934005581:task-definition/backend-job-451934005581:1020"
+  assert_not_contains "$(cat "$tmpdir/capture/aws-calls.txt")" "ecs list-clusters"
+}
+
+@test "ecs run reports available jobs when named job is unknown" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    missing-job
+
+  [ "$status" -ne 0 ]
+  assert_contains "$output" "No ECS job named 'missing-job' found in staging"
+  assert_contains "$output" "backend-database-replication"
+  assert_contains "$output" "backend-database-backup"
+}
+
+@test "ecs run requires environment when named scheduled job is ambiguous" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_INCLUDE_DEVELOPMENT_REPLICATION=true "$repo_root/bin/ecs" \
+    run \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -ne 0 ]
+  assert_contains "$output" "Multiple ECS jobs named 'backend-database-replication' found"
+  assert_contains "$output" "backend-database-replication (development)"
+  assert_contains "$output" "backend-database-replication (staging)"
+  assert_contains "$output" "Specify --environment to choose one"
+}
+
+@test "ecs run detects production jobs from the current AWS account" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_INCLUDE_PRODUCTION_ONLY=true "$repo_root/bin/ecs" \
+    run \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+  assert_contains "$(cat "$tmpdir/capture/run-task-args.txt")" "--cluster trade-tariff-cluster-production"
+  assert_contains "$(cat "$tmpdir/capture/run-task-args.txt")" "--task-definition arn:aws:ecs:eu-west-2:382373577178:task-definition/backend-job-382373577178:901"
+}
+
+@test "ecs run allows production when environment is explicit" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_INCLUDE_PRODUCTION_ONLY=true "$repo_root/bin/ecs" \
+    run \
+    --environment production \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+
+  run_task_args="$(cat "$tmpdir/capture/run-task-args.txt")"
+  assert_contains "$run_task_args" "--cluster trade-tariff-cluster-production"
+  assert_contains "$run_task_args" "--task-definition arn:aws:ecs:eu-west-2:382373577178:task-definition/backend-job-382373577178:901"
+}
+
+@test "ecs run reports AWS run-task failures and exits non-zero" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_RUN_TASK_FAILURE=true "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -ne 0 ]
+  assert_contains "$output" "Failed to start task"
+  assert_contains "$output" "CLIENT_EXCEPTION"
+  assert_contains "$output" "TaskDefinition is inactive"
+  assert_not_contains "$output" "Started task: null"
+}
+
+@test "ecs run fails when AWS run-task response has no task ARN" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_RUN_TASK_NULL_ARN=true "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -ne 0 ]
+  assert_contains "$output" "AWS response did not include a task ARN"
+  assert_not_contains "$output" "Started task: null"
+}
+
+@test "ecs run uses requested region for direct named jobs" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --region eu-west-1 \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+  assert_not_contains "$(cat "$tmpdir/capture/aws-calls.txt")" "--region eu-west-2"
+  assert_contains "$(cat "$tmpdir/capture/aws-calls.txt")" "--region eu-west-1"
+}
+
+@test "ecs run direct named jobs do not require fzf" {
+  write_common_stubs none
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Started task: task-123"
+}
+
+@test "ecs run rejects multiple ECS targets for a scheduled rule" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env TEST_CAPTURE_DIR="$tmpdir/capture" TEST_MULTIPLE_STAGING_TARGETS=true "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    --no-tail \
+    backend-database-replication
+
+  [ "$status" -ne 0 ]
+  assert_contains "$output" "Expected exactly one ECS target"
+  assert_contains "$output" "target-a"
+  assert_contains "$output" "target-b"
+}
+
+@test "ecs run exits non-zero when the ECS task fails" {
+  write_common_stubs
+  mkdir -p "$tmpdir/capture"
+
+  run env \
+    TEST_CAPTURE_DIR="$tmpdir/capture" \
+    TEST_TASK_EXIT_CODE=23 \
+    TASK_POLL_SECONDS=0 \
+    FINAL_LOG_FLUSH_SECONDS=0 \
+    "$repo_root/bin/ecs" \
+    run \
+    --environment staging \
+    --yes \
+    backend-database-replication
+
+  [ "$status" -eq 23 ]
+  assert_contains "$output" "Task failed (exit code: 23)"
+  assert_contains "$output" "Stopped reason: Essential container in task exited"
+  assert_contains "$output" "Container reason: test reason"
+}


### PR DESCRIPTION
## What

Adds non-interactive scheduled-job selection to `bin/ecs run`, so a unique EventBridge-backed ECS job can be started directly by name:

```bash
./bin/ecs run backend-database-replication
./bin/ecs run --yes --no-tail backend-database-replication
```

`--environment` remains available when the same job name exists in more than one environment:

```bash
./bin/ecs run --environment staging --yes --no-tail backend-database-replication
```

Production jobs are never inferred by name alone; production requires `--environment production`.

## Why

The staging replication rule can point at an inactive task definition revision, which causes AWS to reject the run with:

```text
An error occurred (InvalidParameterException) when calling the RunTask operation: TaskDefinition is inactive
```

The EventBridge target is still useful for discovering the job command, container override, family, and target cluster, but the task definition revision needs refreshing at run time.