### PR TITLE
[HMRC-2449] Add importmaps update action

### DIFF
--- a/.github/actions/importmap-update/action.yml
+++ b/.github/actions/importmap-update/action.yml
@@ -1,0 +1,35 @@
+name: Update importmap dependencies
+description: Run thoughtbot/importmap-update to open dependabot style PRs for outdated importmap packages 
+
+inputs:
+  github-token:
+    description: >-
+      Token used for checkout and for creating, updating, and closing importmap
+      update pull requests. The caller workflow needs contents: write and
+      pull-requests: write permissions.
+    required: false
+    default: ${{ github.token }}
+  dry-run:
+    description: Run importmap-update without creating, updating, or closing pull requests.
+    required: false
+    default: 'false'
+  bundler-cache:
+    description: Whether ruby/setup-ruby should install and cache bundle dependencies.
+    required: false
+    default: 'true'
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v7.0.0
+      with:
+        token: ${{ inputs.github-token }}
+
+    - uses: ruby/setup-ruby@v1.316.0
+      with:
+        bundler-cache: ${{ inputs.bundler-cache }}
+
+    - uses: thoughtbot/importmap-update@v1.0.0-alpha3
+      with:
+        github-token: ${{ inputs.github-token }}
+        dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - '.github/actions/auto-merge-low-risk/**'
       - '.github/actions/check-pr-lines/**'
       - '.github/actions/debride/**'
+      - '.github/actions/importmap-update/**'
       - '.github/workflows/auto-merge-low-risk.yml'
       - '.pre-commit-hooks.yaml'
       - 'scripts/deploy-pr-info.sh'

--- a/tests/importmap-update-action.bats
+++ b/tests/importmap-update-action.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "importmap-update action checks out the caller repository with the update token" {
+  action="$repo_root/.github/actions/importmap-update/action.yml"
+
+  run grep -F "uses: actions/checkout@v7.0.0" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'token: ${{ inputs.github-token }}' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "importmap-update action sets up Ruby before running the updater" {
+  action="$repo_root/.github/actions/importmap-update/action.yml"
+
+  run grep -F "uses: ruby/setup-ruby@v1.316.0" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'bundler-cache: ${{ inputs.bundler-cache }}' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "importmap-update action delegates to thoughtbot importmap-update" {
+  action="$repo_root/.github/actions/importmap-update/action.yml"
+
+  run grep -F "uses: thoughtbot/importmap-update@v1.0.0-alpha3" "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'github-token: ${{ inputs.github-token }}' "$action"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'dry-run: ${{ inputs.dry-run }}' "$action"
+  [ "$status" -eq 0 ]
+}
+
+@test "ci runs when the importmap-update action changes" {
+  workflow="$repo_root/.github/workflows/ci.yml"
+
+  run grep -F ".github/actions/importmap-update/**" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Jira link

[HMRC-2449](https://transformuk.atlassian.net/browse/HMRC-2449)

### What?

Adds [thoughtbot/importmap-update@v1.0.0-alpha3](https://github.com/thoughtbot/importmap-update) action to tools for dependabot style PRs for importmaps.

### Why?

Dependabot does not support importmaps. This gives us dependabot style PRs for importmaps updates.