### PR TITLE
HMRC-2466: Exclude generated assets from PR line counts

### DIFF
--- a/.github/actions/check-pr-lines/action.yml
+++ b/.github/actions/check-pr-lines/action.yml
@@ -2,6 +2,7 @@ name: Check PR line count
 description: >-
   Fail when a pull request changes more lines than the configured threshold.
   Supports pull_request and push events (push looks up the open PR for the branch).
+  Generated Rails asset outputs are excluded from the count by default.
 
 inputs:
   threshold:

--- a/.github/actions/check-pr-lines/check-pr-lines.sh
+++ b/.github/actions/check-pr-lines/check-pr-lines.sh
@@ -70,7 +70,11 @@ fi
 
 merge_base="$(git merge-base "$merge_base_input" "$head_sha")"
 
-exclude_specs=()
+exclude_specs=(
+  ":(exclude)app/assets/builds/**"
+  ":(exclude)public/assets/**"
+  ":(exclude)vendor/javascript/**"
+)
 if [[ -n "$exclude_paths_file" && -f "$exclude_paths_file" ]]; then
   while IFS= read -r pattern || [[ -n "$pattern" ]]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"

--- a/tests/check-pr-lines.bats
+++ b/tests/check-pr-lines.bats
@@ -68,6 +68,27 @@ teardown() {
   rm -f "$exclude_file"
 }
 
+@test "excludes generated and vendored Rails assets by default" {
+  mkdir -p "$repo/vendor/javascript" "$repo/app/assets/builds" "$repo/public/assets"
+  seq 1 700 > "$repo/vendor/javascript/govuk-frontend.js"
+  seq 1 700 > "$repo/app/assets/builds/application.js"
+  seq 1 700 > "$repo/public/assets/application-digest.js"
+  printf 'app change\n' > "$repo/app.rb"
+  git -C "$repo" add app.rb vendor/javascript/govuk-frontend.js app/assets/builds/application.js public/assets/application-digest.js
+  git -C "$repo" commit -qm "add generated assets"
+  head_with_assets="$(git -C "$repo" rev-parse HEAD)"
+
+  cd "$repo" || return 1
+
+  run bash "$script" \
+    --threshold 2 \
+    --base "$base_sha" \
+    --head "$head_with_assets"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PR changes 2 lines"* ]]
+}
+
 @test "counts changes from the merge base when the base branch has moved" {
   git -C "$repo" switch -qc pr-branch "$base_sha"
   printf 'branch change\n' > "$repo/feature.txt"


### PR DESCRIPTION
### Jira link

[HMRC-2466](https://transformuk.atlassian.net/browse/HMRC-2466)

### What?

- [x] Add default `check-pr-lines` exclusions for generated/vendored Rails asset outputs:
  - `app/assets/builds/**`
  - `public/assets/**`
  - `vendor/javascript/**`
- [x] Keep caller-provided `exclude-paths` additive.
- [x] Add Bats coverage proving large generated/vendored assets do not count towards the threshold.

### Why?

`trade-tariff-admin` PR 1337 vendors `vendor/javascript/govuk-frontend.js`, which is a large generated asset and causes the shared PR line-count check to fail even though the reviewable application change is small.

Changing the shared action covers the current consumers found by GitHub code search without repeating the same asset exclusions in each app workflow: backend, frontend, identity, admin, and dev-hub.

### Risk

**Risk level:** 🟢

**Reason for rating:** CI-only shared action change with focused regression coverage. It narrows line-count enforcement for generated/vendored asset outputs while preserving normal code counting and existing caller exclusions.
