### PR TITLE
Add CODEOWNERS with team ownership and Copilot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @AigulDj @willfish @amberstarlight
+*  @trade-tariff/trade-tariff-platform @github-copilot


### PR DESCRIPTION
## What:

- [x] Add or update root `CODEOWNERS`
- [x] Set default owners to `@trade-tariff/trade-tariff-platform`
- [x] Add `@github-copilot` for automatic Copilot review

## Why:

Make review ownership explicit for infrastructure and platform repositories, and ensure Copilot is requested on pull requests.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Meta-only CODEOWNERS change with no runtime behaviour, deployment, or infrastructure resource impact.
