### PR TITLE
[HMRC-2449] Add config to importmap updates

### DIFF
--- a/.github/actions/importmap-update/action.yml
+++ b/.github/actions/importmap-update/action.yml
@@ -31,5 +31,6 @@ runs:
 
     - uses: thoughtbot/importmap-update@v1.0.0-alpha3
       with:
+        config-file: ${{ github.action_path }}/importmap-updates.yml
         github-token: ${{ inputs.github-token }}
         dry-run: ${{ inputs.dry-run }}

--- a/.github/actions/importmap-update/importmap-updates.yml
+++ b/.github/actions/importmap-update/importmap-updates.yml
@@ -1,0 +1,3 @@
+version: 1
+labels:
+  - dependencies


### PR DESCRIPTION
### Jira link

[HMRC-2449](https://transformuk.atlassian.net/browse/HMRC-2449)

### What?

Adds config file to the github action for dependabot style importmap updates to limit the number of labels used.

### Why?

By default, `thoughtbot/importmap-update` tries to label PRs `dependencies`, `javascript`, `importmaps` and currently fails because it uses a deprecated octokit method to create the label.

This adds a config file to limit the labelling to `dependencies`, a single label which all repos already have, instead of trying to create new labels or adding 3 labels to a PR.
