### PR TITLE
fix(actions): restore reliable low-risk auto-merge

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -67,23 +67,6 @@ runs:
           fi
         }
 
-        request_copilot_review() {
-          pending="$(gh pr view "$PR_NUMBER" \
-            --repo "$repo" \
-            --json reviewRequests \
-            -q '[.reviewRequests[]? | select(.login | test("copilot"; "i"))] | length')"
-
-          if [[ "${pending:-0}" -gt 0 ]]; then
-            echo "Copilot review already requested on PR #$PR_NUMBER."
-            return 0
-          fi
-
-          echo "Requesting Copilot code review for PR #$PR_NUMBER"
-          if ! gh pr edit "$PR_NUMBER" --repo "$repo" --add-reviewer copilot; then
-            echo "::warning::Unable to request Copilot code review for PR #$PR_NUMBER; auto-merge will retry after a review is available."
-          fi
-        }
-
         # Label removed — turn off auto-merge.
         if [[ "$PR_EVENT_ACTION" == "unlabeled" && "$PR_EVENT_LABEL" == "$AUTO_MERGE_LABEL" ]]; then
           disable_auto_merge
@@ -91,11 +74,14 @@ runs:
         fi
 
         gate_script="${{ github.action_path }}/check-copilot-review-gate.sh"
-        if [[ ! -f "$gate_script" ]]; then
-          echo "::error::Missing ${gate_script}" >&2
-          exit 1
-        fi
-        chmod +x "$gate_script"
+        request_script="${{ github.action_path }}/request-copilot-review.sh"
+        for helper in "$gate_script" "$request_script"; do
+          if [[ ! -f "$helper" ]]; then
+            echo "::error::Missing ${helper}" >&2
+            exit 1
+          fi
+          chmod +x "$helper"
+        done
 
         case "$AUTO_MERGE_METHOD" in
           merge|squash|rebase) ;;
@@ -121,7 +107,7 @@ runs:
         set -e
 
         if [[ "$gate_status" -eq 2 ]]; then
-          request_copilot_review
+          "$request_script" --repo "$repo" --pr "$PR_NUMBER"
           echo "Waiting for Copilot to review PR #$PR_NUMBER; auto-merge will be retried on the next workflow run."
           exit 0
         fi

--- a/.github/actions/auto-merge-low-risk/request-copilot-review.sh
+++ b/.github/actions/auto-merge-low-risk/request-copilot-review.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Request Copilot review unless an outstanding Copilot request already exists.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: request-copilot-review.sh --repo <owner/name> --pr <number>
+EOF
+}
+
+repo=""
+pr=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$repo" || -z "$pr" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+pending="$(gh pr view "$pr" \
+  --repo "$repo" \
+  --json reviewRequests \
+  -q '[.reviewRequests[]? | select((.login // "") | test("copilot"; "i"))] | length')"
+
+if [[ "${pending:-0}" -gt 0 ]]; then
+  echo "Copilot review already requested on PR #$pr."
+  exit 0
+fi
+
+echo "Requesting Copilot code review for PR #$pr"
+if ! gh pr edit "$pr" --repo "$repo" --add-reviewer copilot; then
+  echo "::warning::Unable to request Copilot code review for PR #$pr; auto-merge will retry after a review is available."
+fi

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -27,8 +27,9 @@ permissions:
 jobs:
   auto-merge:
     if: >-
-      github.event_name != 'pull_request' ||
-      !github.event.pull_request.draft
+      (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
+      (github.event_name != 'pull_request_review' ||
+      contains(github.event.review.user.login, 'copilot'))
     runs-on: ubuntu-latest
     steps:
       - name: Resolve pull request number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/debride/debride-check .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
+        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/debride/debride-check .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh .github/actions/auto-merge-low-risk/request-copilot-review.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -1,0 +1,89 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  tmpdir="$(mktemp -d)"
+  setup_stub_path
+  export GH_CAPTURE_FILE="$tmpdir/gh-edit-args.txt"
+
+  cat > "$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  query=""
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == "-q" ]]; then
+      query="$2"
+      break
+    fi
+    shift
+  done
+  jq -r "$query" <<< "$GH_REVIEW_REQUESTS_JSON"
+  exit 0
+fi
+
+if [[ "$1" == "pr" && "$2" == "edit" ]]; then
+  printf '%s\n' "$@" > "$GH_CAPTURE_FILE"
+  exit "${GH_EDIT_STATUS:-0}"
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$stub_bin/gh"
+}
+
+teardown() {
+  rm -rf "$tmpdir"
+}
+
+@test "requests Copilot when a team review request has no login" {
+  export GH_REVIEW_REQUESTS_JSON='{"reviewRequests":[{"__typename":"Team","name":"trade-tariff-core"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/request-copilot-review.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Requesting Copilot code review for PR #42"
+  run grep -Fx -- "--add-reviewer" "$GH_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+  run grep -Fx "copilot" "$GH_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "does not duplicate an outstanding Copilot review request" {
+  export GH_REVIEW_REQUESTS_JSON='{"reviewRequests":[{"__typename":"User","login":"copilot-pull-request-reviewer[bot]"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/request-copilot-review.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Copilot review already requested on PR #42."
+  [ ! -e "$GH_CAPTURE_FILE" ]
+}
+
+@test "warns and succeeds when GitHub rejects the Copilot request" {
+  export GH_REVIEW_REQUESTS_JSON='{"reviewRequests":[]}'
+  export GH_EDIT_STATUS=1
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/request-copilot-review.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "::warning::Unable to request Copilot code review for PR #42; auto-merge will retry after a review is available."
+}
+
+@test "reusable workflow only handles Copilot review events" {
+  workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
+
+  run grep -F "github.event_name != 'pull_request_review' ||" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "contains(github.event.review.user.login, 'copilot')" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What:

- [x] Make Copilot review-request detection tolerate team review requests without a `login`.
- [x] Extract review requesting into a tested shell helper.
- [x] Limit submitted-review handling to Copilot events to avoid approval-trigger loops.
- [x] Add regression coverage for team requests, duplicate requests, request failures, and event filtering.

## Why:

The low-risk auto-merge action failed when GitHub returned a team review request without a `login`. The existing jq expression attempted to test that null value and exited before the workflow could request or evaluate Copilot's review.

The null-safe helper restores the intended flow while preserving the existing retry behaviour. Filtering submitted-review events to Copilot prevents later automated or human approvals from recursively triggering the workflow.

## Ticket:

[HMRC-2474](https://transformuk.atlassian.net/browse/HMRC-2474)

## Risk:

**Risk level:** 🟢 Green

**Reason for rating:**

This is a focused, reversible change to reusable GitHub Actions review handling. It is covered by regression tests and can be reverted independently.
