### PR TITLE
Block auto-merge when Copilot review quota is exhausted

### DIFF
--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -88,7 +88,7 @@ read -r copilot_review_count copilot_quota_exhausted <<< "$(gh pr view "$pr" \
   -q "$COPILOT_REVIEW_JQ")"
 
 if [[ "$copilot_quota_exhausted" == "true" ]]; then
-  echo "::warning::Copilot could not review PR #$pr because its review quota is exhausted; blocking auto-merge." >&2
+  echo "::warning::Copilot could not review PR #$pr because its review quota is exhausted; blocking auto-merge. GitHub reports that the user who requested the review has reached their quota or budget limit." >&2
   exit 1
 fi
 

--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -71,12 +71,26 @@ COPILOT_REVIEW_JQ='[
       or .author.login == "github-copilot[bot]"
       or ((.author.login // "") | test("copilot"; "i"))
     )
-] | length'
+] as $reviews
+| [
+    ($reviews | length),
+    ($reviews
+      | sort_by(.submittedAt // "")
+      | last
+      | (.body // "")
+      | test("reached (their|the) (quota|budget) limit"; "i"))
+  ]
+| @tsv'
 
-copilot_review_count="$(gh pr view "$pr" \
+read -r copilot_review_count copilot_quota_exhausted <<< "$(gh pr view "$pr" \
   --repo "$repo" \
   --json reviews \
   -q "$COPILOT_REVIEW_JQ")"
+
+if [[ "$copilot_quota_exhausted" == "true" ]]; then
+  echo "::warning::Copilot could not review PR #$pr because its review quota is exhausted; blocking auto-merge." >&2
+  exit 1
+fi
 
 if [[ "${copilot_review_count:-0}" -lt 1 ]]; then
   echo "PR #$pr has not been reviewed by Copilot yet." >&2

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -87,6 +87,7 @@ teardown() {
 
   [ "$status" -eq 1 ]
   assert_contains "$output" "Copilot could not review PR #42 because its review quota is exhausted; blocking auto-merge."
+  assert_contains "$output" "GitHub reports that the user who requested the review has reached their quota or budget limit."
 }
 
 @test "reusable workflow only handles Copilot review events" {

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -78,6 +78,17 @@ teardown() {
   assert_contains "$output" "::warning::Unable to request Copilot code review for PR #42; auto-merge will retry after a review is available."
 }
 
+@test "blocks auto-merge when Copilot cannot review because its quota is exhausted" {
+  export GH_REVIEW_REQUESTS_JSON='{"reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.","submittedAt":"2026-07-16T15:47:00Z"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Copilot could not review PR #42 because its review quota is exhausted; blocking auto-merge."
+}
+
 @test "reusable workflow only handles Copilot review events" {
   workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
 


### PR DESCRIPTION
### Jira link

No ticket/issue

### What?

I have altered:

- [x] Treat the latest Copilot quota or budget-limit response as a failed review gate
- [x] Block approval and auto-merge without immediately requesting another review
- [x] Add regression coverage using the response returned by Copilot

### Why?

I am doing this because:

- Copilot submits quota exhaustion as a COMMENTED review, so the gate counted it as a completed review
- With no inline review threads, that response allowed low-risk PRs to be approved and merged without a code review
- Replaying the gate against trade-tariff-backend PR 3498 now exits 1 and reports that auto-merge is blocked
- **Risk level:** 🟢 Low. This only changes merge automation and fails closed by delaying the merge when Copilot cannot review

### Have you? (optional)

- [x] Added a regression test for the quota-exhausted response
- [x] Run Bash syntax checks and all 91 Bats tests
- [x] Run the repository pre-commit hooks, including ShellCheck and TruffleHog
- [x] Respected peoples right not to receive lots of noisy messages