### PR TITLE
Gate low-risk auto-merge on the current head

### DIFF
--- a/.github/actions/auto-merge-low-risk/action.yml
+++ b/.github/actions/auto-merge-low-risk/action.yml
@@ -1,8 +1,8 @@
 name: Auto-merge low-risk PR
 description: >-
-  Enable or disable GitHub auto-merge for low-risk PRs. Requests Copilot review
-  when needed, then enables auto-merge once Copilot has reviewed and all Copilot
-  threads are resolved.
+  Merge low-risk PRs after the current head is reviewed, all Copilot threads
+  are resolved, and the current pull request checks are green. Disable any
+  legacy auto-merge request before evaluating fresh gates.
 
 inputs:
   pr-number:
@@ -19,6 +19,10 @@ inputs:
     description: 'merge, squash, or rebase.'
     required: false
     default: merge
+  required-workflow:
+    description: Workflow file that must succeed for the current pull request head.
+    required: false
+    default: ci.yml
   pull-request-event-action:
     description: >-
       github.event.action from the caller workflow (e.g. labeled, unlabeled).
@@ -41,100 +45,18 @@ runs:
         PR_NUMBER: ${{ inputs.pr-number }}
         AUTO_MERGE_LABEL: ${{ inputs.label }}
         AUTO_MERGE_METHOD: ${{ inputs.merge-method }}
+        REQUIRED_WORKFLOW: ${{ inputs.required-workflow }}
         PR_EVENT_ACTION: ${{ inputs.pull-request-event-action }}
         PR_EVENT_LABEL: ${{ inputs.pull-request-event-label }}
       run: |
         set -euo pipefail
-
-        repo="${{ github.repository }}"
-
-        disable_auto_merge() {
-          auto_merge_enabled=$(
-            gh pr view "$PR_NUMBER" \
-              --repo "$repo" \
-              --json autoMergeRequest \
-              -q '.autoMergeRequest != null'
-          )
-
-          if [[ "$auto_merge_enabled" == "true" ]]; then
-            echo "Disabling auto-merge for PR #$PR_NUMBER"
-            gh pr merge "$PR_NUMBER" \
-              --repo "$repo" \
-              "--${AUTO_MERGE_METHOD}" \
-              --disable-auto
-          else
-            echo "Auto-merge is not enabled for PR #$PR_NUMBER; nothing to disable."
-          fi
-        }
-
-        # Label removed — turn off auto-merge.
-        if [[ "$PR_EVENT_ACTION" == "unlabeled" && "$PR_EVENT_LABEL" == "$AUTO_MERGE_LABEL" ]]; then
-          disable_auto_merge
-          exit 0
-        fi
-
-        gate_script="${{ github.action_path }}/check-copilot-review-gate.sh"
-        request_script="${{ github.action_path }}/request-copilot-review.sh"
-        for helper in "$gate_script" "$request_script"; do
-          if [[ ! -f "$helper" ]]; then
-            echo "::error::Missing ${helper}" >&2
-            exit 1
-          fi
-          chmod +x "$helper"
-        done
-
-        case "$AUTO_MERGE_METHOD" in
-          merge|squash|rebase) ;;
-          *)
-            echo "::error::Invalid merge-method: $AUTO_MERGE_METHOD (expected merge, squash, or rebase)" >&2
-            exit 1
-            ;;
-        esac
-
-        labels="$(gh pr view "$PR_NUMBER" \
-          --repo "$repo" \
-          --json labels \
-          -q '.labels[].name')"
-
-        if ! grep -qx "$AUTO_MERGE_LABEL" <<< "$labels"; then
-          echo "PR #$PR_NUMBER does not have the ${AUTO_MERGE_LABEL} label; skipping."
-          exit 0
-        fi
-
-        set +e
-        "$gate_script" --repo "$repo" --pr "$PR_NUMBER"
-        gate_status=$?
-        set -e
-
-        if [[ "$gate_status" -eq 2 ]]; then
-          "$request_script" --repo "$repo" --pr "$PR_NUMBER"
-          echo "Waiting for Copilot to review PR #$PR_NUMBER; auto-merge will be retried on the next workflow run."
-          exit 0
-        fi
-
-        if [[ "$gate_status" -ne 0 ]]; then
-          echo "Copilot review requirements not met for PR #$PR_NUMBER; skipping auto-merge."
-          exit 0
-        fi
-
-        gh pr review "$PR_NUMBER" \
-          --repo "$repo" \
-          --approve
-
-        auto_merge_enabled=$(
-          gh pr view "$PR_NUMBER" \
-            --repo "$repo" \
-            --json autoMergeRequest \
-            -q '.autoMergeRequest != null'
-        )
-
-        if [[ "$auto_merge_enabled" == "true" ]]; then
-          echo "Auto-merge already enabled for PR #$PR_NUMBER."
-          exit 0
-        fi
-
-        echo "Enabling auto-merge (${AUTO_MERGE_METHOD}) for PR #$PR_NUMBER"
-        gh pr merge "$PR_NUMBER" \
-          --repo "$repo" \
-          "--${AUTO_MERGE_METHOD}" \
-          --auto
+        orchestrator="${{ github.action_path }}/auto-merge.sh"
+        chmod +x "$orchestrator"
+        "$orchestrator" \
+          --repo "${{ github.repository }}" \
+          --pr "$PR_NUMBER" \
+          --label "$AUTO_MERGE_LABEL" \
+          --merge-method "$AUTO_MERGE_METHOD" \
+          --required-workflow "$REQUIRED_WORKFLOW" \
+          --event-action "$PR_EVENT_ACTION" \
+          --event-label "$PR_EVENT_LABEL"

--- a/.github/actions/auto-merge-low-risk/approve-pull-request.sh
+++ b/.github/actions/auto-merge-low-risk/approve-pull-request.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Approve only the expected, currently ready pull request head.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: approve-pull-request.sh --repo <owner/name> --pr <number> --head <expected-oid>
+EOF
+}
+
+repo=""
+pr=""
+expected_head=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --head)
+      expected_head="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$repo" || -z "$pr" || -z "$expected_head" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+pull_request="$(gh pr view "$pr" \
+  --repo "$repo" \
+  --json headRefOid,isDraft)"
+current_head="$(jq -r '.headRefOid' <<< "$pull_request")"
+
+if [[ "$current_head" != "$expected_head" ]]; then
+  echo "PR #$pr head changed from $expected_head to $current_head; refusing approval." >&2
+  exit 1
+fi
+
+if [[ "$(jq -r '.isDraft' <<< "$pull_request")" == "true" ]]; then
+  echo "PR #$pr is a draft; refusing approval." >&2
+  exit 1
+fi
+
+gh api \
+  --method POST \
+  "repos/$repo/pulls/$pr/reviews" \
+  -f event=APPROVE \
+  -f commit_id="$expected_head"

--- a/.github/actions/auto-merge-low-risk/auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/auto-merge.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Orchestrate current-head review, pull-request state, approval, and merge gates.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: auto-merge.sh --repo <owner/name> --pr <number> --label <label> \
+  --merge-method <merge|squash|rebase> --required-workflow <workflow> \
+  [--event-action <action>] [--event-label <label>]
+EOF
+}
+
+repo=""
+pr=""
+label=""
+merge_method=""
+required_workflow=""
+event_action=""
+event_label=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="$2"; shift 2 ;;
+    --pr) pr="$2"; shift 2 ;;
+    --label) label="$2"; shift 2 ;;
+    --merge-method) merge_method="$2"; shift 2 ;;
+    --required-workflow) required_workflow="$2"; shift 2 ;;
+    --event-action) event_action="$2"; shift 2 ;;
+    --event-label) event_label="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$repo" || -z "$pr" || -z "$label" || -z "$merge_method" || -z "$required_workflow" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+case "$merge_method" in
+  merge|squash|rebase) ;;
+  *)
+    echo "::error::Invalid merge-method: $merge_method (expected merge, squash, or rebase)" >&2
+    exit 1
+    ;;
+esac
+
+action_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+approval_script="$action_path/approve-pull-request.sh"
+disable_script="$action_path/disable-auto-merge.sh"
+gate_script="$action_path/check-copilot-review-gate.sh"
+state_gate_script="$action_path/check-pull-request-state-gate.sh"
+request_script="$action_path/request-copilot-review.sh"
+
+for helper in "$approval_script" "$disable_script" "$gate_script" "$state_gate_script" "$request_script"; do
+  if [[ ! -f "$helper" ]]; then
+    echo "::error::Missing ${helper}" >&2
+    exit 1
+  fi
+  chmod +x "$helper"
+done
+
+"$disable_script" --repo "$repo" --pr "$pr" --merge-method "$merge_method"
+
+# Label removal only needs to disarm any legacy auto-merge request.
+if [[ "$event_action" == "unlabeled" && "$event_label" == "$label" ]]; then
+  exit 0
+fi
+
+labels="$(gh pr view "$pr" --repo "$repo" --json labels -q '.labels[].name')"
+if ! grep -qx "$label" <<< "$labels"; then
+  echo "PR #$pr does not have the ${label} label; skipping."
+  exit 0
+fi
+
+expected_head="$(gh pr view "$pr" --repo "$repo" --json headRefOid -q '.headRefOid')"
+
+set +e
+"$gate_script" --repo "$repo" --pr "$pr" --head "$expected_head"
+gate_status=$?
+set -e
+
+if [[ "$gate_status" -eq 2 ]]; then
+  "$request_script" --repo "$repo" --pr "$pr"
+  echo "Waiting for Copilot to review PR #$pr; auto-merge will be retried on the next workflow run."
+  exit 0
+fi
+if [[ "$gate_status" -ne 0 ]]; then
+  echo "Copilot review requirements not met for PR #$pr; skipping auto-merge."
+  exit 0
+fi
+
+set +e
+"$state_gate_script" \
+  --repo "$repo" \
+  --pr "$pr" \
+  --workflow "$required_workflow" \
+  --head "$expected_head"
+state_gate_status=$?
+set -e
+
+if [[ "$state_gate_status" -ne 0 ]]; then
+  echo "Pull request state or workflow requirements not met for PR #$pr; skipping auto-merge."
+  exit 0
+fi
+
+"$approval_script" --repo "$repo" --pr "$pr" --head "$expected_head"
+
+echo "Merging PR #$pr at $expected_head (${merge_method})"
+gh pr merge "$pr" \
+  --repo "$repo" \
+  "--${merge_method}" \
+  --match-head-commit "$expected_head"

--- a/.github/actions/auto-merge-low-risk/auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/auto-merge.sh
@@ -69,7 +69,7 @@ if [[ "$event_action" == "unlabeled" && "$event_label" == "$label" ]]; then
 fi
 
 labels="$(gh pr view "$pr" --repo "$repo" --json labels -q '.labels[].name')"
-if ! grep -qx "$label" <<< "$labels"; then
+if ! grep -Fqx "$label" <<< "$labels"; then
   echo "PR #$pr does not have the ${label} label; skipping."
   exit 0
 fi

--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -75,7 +75,7 @@ COPILOT_REVIEW_JQ='. as $pr
     or . == "copilot-pull-request-reviewer[bot]"
     or . == "github-copilot[bot]";
 [
-  .reviews[]
+  .reviews[]?
   | select(.author.login | copilot_login)
   | select(.commit.oid == $pr.headRefOid)
 ] as $reviews

--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -9,7 +9,7 @@ Usage: check-copilot-review-gate.sh --repo <owner/name> --pr <number> [--head <e
 Exits 0 when Copilot has reviewed the current PR head and every Copilot inline
 review thread is resolved.
 Exits 2 when Copilot has not reviewed the current PR head yet.
-Exits 1 when Copilot review threads are still unresolved.
+Exits 1 when a Copilot review requirement blocks auto-merge.
 EOF
 }
 

--- a/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh
@@ -4,17 +4,18 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: check-copilot-review-gate.sh --repo <owner/name> --pr <number>
+Usage: check-copilot-review-gate.sh --repo <owner/name> --pr <number> [--head <expected-oid>]
 
-Exits 0 when Copilot has submitted at least one PR review and every Copilot
-inline review thread is resolved.
-Exits 2 when Copilot has not reviewed yet.
+Exits 0 when Copilot has reviewed the current PR head and every Copilot inline
+review thread is resolved.
+Exits 2 when Copilot has not reviewed the current PR head yet.
 Exits 1 when Copilot review threads are still unresolved.
 EOF
 }
 
 repo=""
 pr=""
+expected_head=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,6 +25,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --pr)
       pr="$2"
+      shift 2
+      ;;
+    --head)
+      expected_head="$2"
       shift 2
       ;;
     -h|--help)
@@ -63,14 +68,16 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Copilot code review author logins (see GitHub Copilot code review docs).
-COPILOT_REVIEW_JQ='[
+COPILOT_REVIEW_JQ='. as $pr
+| def copilot_login:
+    . == "copilot"
+    or . == "copilot-pull-request-reviewer"
+    or . == "copilot-pull-request-reviewer[bot]"
+    or . == "github-copilot[bot]";
+[
   .reviews[]
-  | select(
-      .author.login == "copilot"
-      or .author.login == "copilot-pull-request-reviewer"
-      or .author.login == "github-copilot[bot]"
-      or ((.author.login // "") | test("copilot"; "i"))
-    )
+  | select(.author.login | copilot_login)
+  | select(.commit.oid == $pr.headRefOid)
 ] as $reviews
 | [
     ($reviews | length),
@@ -82,10 +89,17 @@ COPILOT_REVIEW_JQ='[
   ]
 | @tsv'
 
-read -r copilot_review_count copilot_quota_exhausted <<< "$(gh pr view "$pr" \
+review_state="$(gh pr view "$pr" \
   --repo "$repo" \
-  --json reviews \
-  -q "$COPILOT_REVIEW_JQ")"
+  --json headRefOid,reviews)"
+current_head="$(jq -r '.headRefOid' <<< "$review_state")"
+
+if [[ -n "$expected_head" && "$current_head" != "$expected_head" ]]; then
+  echo "PR #$pr head changed from $expected_head to $current_head; blocking auto-merge." >&2
+  exit 1
+fi
+
+read -r copilot_review_count copilot_quota_exhausted <<< "$(jq -r "$COPILOT_REVIEW_JQ" <<< "$review_state")"
 
 if [[ "$copilot_quota_exhausted" == "true" ]]; then
   echo "::warning::Copilot could not review PR #$pr because its review quota is exhausted; blocking auto-merge. GitHub reports that the user who requested the review has reached their quota or budget limit." >&2
@@ -93,7 +107,7 @@ if [[ "$copilot_quota_exhausted" == "true" ]]; then
 fi
 
 if [[ "${copilot_review_count:-0}" -lt 1 ]]; then
-  echo "PR #$pr has not been reviewed by Copilot yet." >&2
+  echo "PR #$pr has not been reviewed by Copilot at its current head." >&2
   exit 2
 fi
 
@@ -127,8 +141,8 @@ while true; do
       -F pr="$pr" \
       -f cursor="$cursor" 2>&1)" || {
       if grep -qi "resource not accessible by personal access token" <<< "$response"; then
-        echo "::warning::Insufficient token permissions to check Copilot review threads. Skipping detailed review gate check. This allows workflow to continue." >&2
-        exit 0
+        echo "::error::Insufficient token permissions to check Copilot review threads; blocking auto-merge." >&2
+        exit 1
       fi
       echo "$response" >&2
       exit 1
@@ -157,8 +171,8 @@ while true; do
       -f repo="$name" \
       -F pr="$pr" 2>&1)" || {
       if grep -qi "resource not accessible by personal access token" <<< "$response"; then
-        echo "::warning::Insufficient token permissions to check Copilot review threads. Skipping detailed review gate check. This allows workflow to continue." >&2
-        exit 0
+        echo "::error::Insufficient token permissions to check Copilot review threads; blocking auto-merge." >&2
+        exit 1
       fi
       echo "$response" >&2
       exit 1
@@ -182,8 +196,8 @@ unresolved="$(jq -s '
   def copilot_login:
     . == "copilot"
     or . == "copilot-pull-request-reviewer"
-    or . == "github-copilot[bot]"
-    or ((. // "") | test("copilot"; "i"));
+    or . == "copilot-pull-request-reviewer[bot]"
+    or . == "github-copilot[bot]";
   [
     .[]
     | select(.isResolved == false)

--- a/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Verify the pull request is ready for auto-merge and its current head is green.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: check-pull-request-state-gate.sh --repo <owner/name> --pr <number> --workflow <workflow> [--head <expected-oid>]
+EOF
+}
+
+repo=""
+pr=""
+workflow=""
+expected_head=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --workflow)
+      workflow="$2"
+      shift 2
+      ;;
+    --head)
+      expected_head="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$repo" || -z "$pr" || -z "$workflow" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+pull_request="$(gh pr view "$pr" \
+  --repo "$repo" \
+  --json headRefOid,isDraft,statusCheckRollup)"
+head_oid="$(jq -r '.headRefOid' <<< "$pull_request")"
+
+if [[ -n "$expected_head" && "$head_oid" != "$expected_head" ]]; then
+  echo "PR #$pr head changed from $expected_head to $head_oid; blocking auto-merge." >&2
+  exit 1
+fi
+
+if [[ "$(jq -r '.isDraft' <<< "$pull_request")" == "true" ]]; then
+  echo "PR #$pr is still a draft; blocking auto-merge." >&2
+  exit 1
+fi
+
+runs="$(gh run list \
+  --repo "$repo" \
+  --workflow "$workflow" \
+  --commit "$head_oid" \
+  --limit 20 \
+  --json headSha,status,conclusion,createdAt)"
+current_run="$(jq -c --arg head "$head_oid" '
+  map(select(.headSha == $head))
+  | sort_by(.createdAt)
+  | last // empty
+' <<< "$runs")"
+
+if [[ -z "$current_run" ]]; then
+  echo "No $workflow run exists for the current head of PR #$pr; blocking auto-merge." >&2
+  exit 1
+fi
+
+run_status="$(jq -r '.status' <<< "$current_run")"
+if [[ "$run_status" != "completed" ]]; then
+  echo "The current-head $workflow run for PR #$pr is $run_status; blocking auto-merge." >&2
+  exit 1
+fi
+
+run_conclusion="$(jq -r '.conclusion' <<< "$current_run")"
+if [[ "$run_conclusion" != "success" ]]; then
+  echo "The current-head $workflow run for PR #$pr concluded $run_conclusion; blocking auto-merge." >&2
+  exit 1
+fi
+
+blocking_checks="$(jq -c '
+  def acceptable_conclusion:
+    . == "SUCCESS" or . == "SKIPPED" or . == "NEUTRAL";
+  [
+    .statusCheckRollup[]
+    | select((.workflowName // "") != "Auto-merge low-risk PRs")
+    | if .__typename == "StatusContext" then
+        select(.state != "SUCCESS")
+        | {
+            label: (.context // "(unnamed status)"),
+            result: (.state // "UNKNOWN")
+          }
+      else
+        select(
+          .status != "COMPLETED"
+          or ((.conclusion // "") | acceptable_conclusion | not)
+        )
+        | {
+            label: (
+              if (.workflowName // "") == "" then
+                (.name // "(unnamed check)")
+              else
+                "\(.workflowName) / \(.name // "(unnamed check)")"
+              end
+            ),
+            result: (
+              if .status != "COMPLETED" then
+                .status
+              else
+                (.conclusion // "UNKNOWN")
+              end
+            )
+          }
+      end
+  ]
+' <<< "$pull_request")"
+blocking_count="$(jq 'length' <<< "$blocking_checks")"
+
+if [[ "$blocking_count" -gt 0 ]]; then
+  noun="checks have"
+  if [[ "$blocking_count" -eq 1 ]]; then
+    noun="check has"
+  fi
+  echo "$blocking_count current-head $noun not completed successfully for PR #$pr:" >&2
+  jq -r '.[] | "  - \(.label): \(.result)"' <<< "$blocking_checks" >&2
+  exit 1
+fi

--- a/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh
+++ b/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh
@@ -97,7 +97,7 @@ blocking_checks="$(jq -c '
   def acceptable_conclusion:
     . == "SUCCESS" or . == "SKIPPED" or . == "NEUTRAL";
   [
-    .statusCheckRollup[]
+    (.statusCheckRollup // [])[]
     | select((.workflowName // "") != "Auto-merge low-risk PRs")
     | if .__typename == "StatusContext" then
         select(.state != "SUCCESS")

--- a/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: disable-auto-merge.sh --repo <owner/name> --pr <number> --merge-method <method>
+Usage: disable-auto-merge.sh --repo <owner/name> --pr <number> --merge-method <merge|squash|rebase>
 EOF
 }
 
@@ -43,6 +43,14 @@ if [[ -z "$repo" || -z "$pr" || -z "$merge_method" ]]; then
   usage >&2
   exit 2
 fi
+
+case "$merge_method" in
+  merge|squash|rebase) ;;
+  *)
+    echo "Invalid merge method: $merge_method (expected merge, squash, or rebase)." >&2
+    exit 2
+    ;;
+esac
 
 auto_merge_enabled="$(gh pr view "$pr" \
   --repo "$repo" \

--- a/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Disable any existing GitHub auto-merge request before evaluating fresh gates.
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: disable-auto-merge.sh --repo <owner/name> --pr <number> --merge-method <method>
+EOF
+}
+
+repo=""
+pr=""
+merge_method=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --pr)
+      pr="$2"
+      shift 2
+      ;;
+    --merge-method)
+      merge_method="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$repo" || -z "$pr" || -z "$merge_method" ]]; then
+  echo "Missing required arguments." >&2
+  usage >&2
+  exit 2
+fi
+
+auto_merge_enabled="$(gh pr view "$pr" \
+  --repo "$repo" \
+  --json autoMergeRequest \
+  -q '.autoMergeRequest != null')"
+
+if [[ "$auto_merge_enabled" == "true" ]]; then
+  echo "Disabling existing auto-merge for PR #$pr"
+  gh pr merge "$pr" \
+    --repo "$repo" \
+    "--${merge_method}" \
+    --disable-auto
+else
+  echo "Auto-merge is not enabled for PR #$pr; nothing to disable."
+fi

--- a/.github/actions/auto-merge-low-risk/request-copilot-review.sh
+++ b/.github/actions/auto-merge-low-risk/request-copilot-review.sh
@@ -42,7 +42,15 @@ fi
 pending="$(gh pr view "$pr" \
   --repo "$repo" \
   --json reviewRequests \
-  -q '[.reviewRequests[]? | select((.login // "") | test("copilot"; "i"))] | length')"
+  -q '[
+    .reviewRequests[]?
+    | select(
+        .login == "copilot"
+        or .login == "copilot-pull-request-reviewer"
+        or .login == "copilot-pull-request-reviewer[bot]"
+        or .login == "github-copilot[bot]"
+      )
+  ] | length')"
 
 if [[ "${pending:-0}" -gt 0 ]]; then
   echo "Copilot review already requested on PR #$pr."
@@ -50,6 +58,6 @@ if [[ "${pending:-0}" -gt 0 ]]; then
 fi
 
 echo "Requesting Copilot code review for PR #$pr"
-if ! gh pr edit "$pr" --repo "$repo" --add-reviewer copilot; then
+if ! gh pr edit "$pr" --repo "$repo" --add-reviewer copilot-pull-request-reviewer; then
   echo "::warning::Unable to request Copilot code review for PR #$pr; auto-merge will retry after a review is available."
 fi

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -26,6 +26,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
 

--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -14,6 +14,11 @@ on:
         type: string
         required: false
         default: merge
+      required-workflow:
+        description: Workflow file that must succeed for the current pull request head.
+        type: string
+        required: false
+        default: ci.yml
 
     secrets:
       github-token:
@@ -29,7 +34,10 @@ jobs:
     if: >-
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
       (github.event_name != 'pull_request_review' ||
-      contains(github.event.review.user.login, 'copilot'))
+      github.event.review.user.login == 'copilot' ||
+      github.event.review.user.login == 'copilot-pull-request-reviewer' ||
+      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' ||
+      github.event.review.user.login == 'github-copilot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Resolve pull request number
@@ -73,6 +81,7 @@ jobs:
           pr-number: ${{ steps.pr.outputs.number }}
           label: ${{ inputs.label }}
           merge-method: ${{ inputs.merge-method }}
+          required-workflow: ${{ inputs.required-workflow }}
           github-token: ${{ secrets.github-token }}
           pull-request-event-action: ${{ github.event.action }}
           pull-request-event-label: ${{ github.event.label.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y bats
 
       - name: Check bash syntax
-        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/debride/debride-check .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh .github/actions/auto-merge-low-risk/request-copilot-review.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
+        run: bash -n scripts/deploy-pr-info.sh scripts/trufflehog-pre-commit.sh scripts/lib/ecs-task-definitions.sh .github/actions/check-pr-lines/check-pr-lines.sh .github/actions/debride/debride-check .github/actions/auto-merge-low-risk/approve-pull-request.sh .github/actions/auto-merge-low-risk/auto-merge.sh .github/actions/auto-merge-low-risk/check-copilot-review-gate.sh .github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh .github/actions/auto-merge-low-risk/disable-auto-merge.sh .github/actions/auto-merge-low-risk/request-copilot-review.sh bin/cleanup-ecs-families bin/db-migrate bin/ecs bin/fetch-commodities bin/ott-search-stat bin/rotate-revisions bin/rotate-task-definitions bin/run-task tests/test_helper.bash
 
       - name: Run regression tests
         run: bats tests

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -158,6 +158,18 @@ teardown() {
   assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
 }
 
+@test "treats a null review collection as not reviewed" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":null}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
+  [[ "$output" != *"Cannot iterate over null"* ]]
+}
+
 @test "does not accept an impostor account as Copilot" {
   export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"helpful-copilot-reviewer"},"commit":{"oid":"current-head"},"body":"","submittedAt":"2026-07-20T08:41:33Z"}]}'
 
@@ -386,6 +398,19 @@ teardown() {
     --workflow ci.yml
 
   [ "$status" -eq 0 ]
+}
+
+@test "treats a null check rollup as empty after exact-head CI succeeds" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":null}'
+  export GH_RUNS_JSON='[{"headSha":"current-head","status":"completed","conclusion":"success","createdAt":"2026-07-20T08:43:10Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Cannot iterate over null"* ]]
 }
 
 @test "reusable workflow wires the current pull request state gate" {

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -470,3 +470,10 @@ EOF
   run grep -F "contains(github.event.review.user.login, 'copilot')" "$workflow"
   [ "$status" -ne 0 ]
 }
+
+@test "reusable workflow can read exact-head workflow runs" {
+  workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
+
+  run grep -F "actions: read" "$workflow"
+  [ "$status" -eq 0 ]
+}

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -174,6 +174,26 @@ teardown() {
   assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
 }
 
+@test "disable helper documents its accepted merge methods" {
+  run "$repo_root/.github/actions/auto-merge-low-risk/disable-auto-merge.sh" --help
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "--merge-method <merge|squash|rebase>"
+}
+
+@test "disable helper rejects an invalid merge method before calling GitHub" {
+  export GH_REVIEW_REQUESTS_JSON='{"autoMergeRequest":{"enabledAt":"2026-07-20T08:40:00Z"}}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/disable-auto-merge.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --merge-method invalid
+
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "Invalid merge method: invalid"
+  [ ! -e "$GH_MERGE_CAPTURE_FILE" ]
+}
+
 @test "Copilot gate rejects a pull request head change during evaluation" {
   export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"new-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"new-head"},"body":"","submittedAt":"2026-07-20T08:45:35Z"}]}'
 

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -127,6 +127,13 @@ teardown() {
   assert_contains "$output" "GitHub reports that the user who requested the review has reached their quota or budget limit."
 }
 
+@test "Copilot gate help describes every exit-one condition as blocking" {
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" --help
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Exits 1 when a Copilot review requirement blocks auto-merge."
+}
+
 @test "requires Copilot to review the current pull request head" {
   export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"previous-head"},"body":"","submittedAt":"2026-07-20T08:41:33Z"}]}'
 

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -6,6 +6,8 @@ setup() {
   tmpdir="$(mktemp -d)"
   setup_stub_path
   export GH_CAPTURE_FILE="$tmpdir/gh-edit-args.txt"
+  export GH_API_CAPTURE_FILE="$tmpdir/gh-api-args.txt"
+  export GH_MERGE_CAPTURE_FILE="$tmpdir/gh-merge-args.txt"
 
   cat > "$stub_bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -20,13 +22,48 @@ if [[ "$1" == "pr" && "$2" == "view" ]]; then
     fi
     shift
   done
-  jq -r "$query" <<< "$GH_REVIEW_REQUESTS_JSON"
+  if [[ -n "$query" ]]; then
+    jq -r "$query" <<< "$GH_REVIEW_REQUESTS_JSON"
+  else
+    printf '%s\n' "$GH_REVIEW_REQUESTS_JSON"
+  fi
   exit 0
 fi
 
 if [[ "$1" == "pr" && "$2" == "edit" ]]; then
   printf '%s\n' "$@" > "$GH_CAPTURE_FILE"
   exit "${GH_EDIT_STATUS:-0}"
+fi
+
+if [[ "$1" == "pr" && "$2" == "merge" ]]; then
+  printf '%s\n' "$@" > "$GH_MERGE_CAPTURE_FILE"
+  if [[ -n "${ORCHESTRATION_LOG:-}" ]]; then
+    printf 'merge %s\n' "$*" >> "$ORCHESTRATION_LOG"
+  fi
+  exit "${GH_MERGE_STATUS:-0}"
+fi
+
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then
+  if [[ "${GH_API_STATUS:-0}" -ne 0 ]]; then
+    printf '%s\n' "${GH_API_OUTPUT:-GraphQL request failed}" >&2
+    exit "$GH_API_STATUS"
+  fi
+  if [[ -n "${GH_THREADS_JSON:-}" ]]; then
+    printf '%s\n' "$GH_THREADS_JSON"
+  else
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+  fi
+  exit 0
+fi
+
+if [[ "$1" == "api" ]]; then
+  printf '%s\n' "$@" > "$GH_API_CAPTURE_FILE"
+  exit "${GH_API_STATUS:-0}"
+fi
+
+if [[ "$1" == "run" && "$2" == "list" ]]; then
+  printf '%s\n' "${GH_RUNS_JSON:-[]}"
+  exit 0
 fi
 
 echo "unexpected gh invocation: $*" >&2
@@ -79,7 +116,7 @@ teardown() {
 }
 
 @test "blocks auto-merge when Copilot cannot review because its quota is exhausted" {
-  export GH_REVIEW_REQUESTS_JSON='{"reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"body":"Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.","submittedAt":"2026-07-16T15:47:00Z"}]}'
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"current-head"},"body":"Copilot was unable to review this pull request because the user who requested the review has reached their quota limit.","submittedAt":"2026-07-16T15:47:00Z"}]}'
 
   run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
     --repo trade-tariff/example \
@@ -90,12 +127,346 @@ teardown() {
   assert_contains "$output" "GitHub reports that the user who requested the review has reached their quota or budget limit."
 }
 
+@test "requires Copilot to review the current pull request head" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"previous-head"},"body":"","submittedAt":"2026-07-20T08:41:33Z"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
+}
+
+@test "does not accept an impostor account as Copilot" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"helpful-copilot-reviewer"},"commit":{"oid":"current-head"},"body":"","submittedAt":"2026-07-20T08:41:33Z"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
+}
+
+@test "disarms an existing auto-merge request before rejecting a stale review" {
+  export GH_REVIEW_REQUESTS_JSON='{"autoMergeRequest":{"enabledAt":"2026-07-20T08:40:00Z"},"headRefOid":"new-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"old-head"},"body":"","submittedAt":"2026-07-20T08:41:33Z"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/disable-auto-merge.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --merge-method rebase
+  [ "$status" -eq 0 ]
+  run grep -Fx -- "--disable-auto" "$GH_MERGE_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+  [ "$status" -eq 2 ]
+  assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
+}
+
+@test "Copilot gate rejects a pull request head change during evaluation" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"new-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"new-head"},"body":"","submittedAt":"2026-07-20T08:45:35Z"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --head expected-head
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "PR #42 head changed from expected-head to new-head; blocking auto-merge."
+}
+
+@test "fails closed when review threads cannot be read" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"current-head"},"body":"","submittedAt":"2026-07-20T08:45:35Z"}]}'
+  export GH_API_STATUS=1
+  export GH_API_OUTPUT='GraphQL: Resource not accessible by personal access token'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "Insufficient token permissions to check Copilot review threads; blocking auto-merge."
+}
+
+@test "passes when Copilot reviewed the current head and has no unresolved threads" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"current-head"},"body":"","submittedAt":"2026-07-20T08:45:35Z"}]}'
+  export GH_THREADS_JSON='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 0 ]
+}
+
+@test "blocks auto-merge when a Copilot thread is unresolved" {
+  export GH_REVIEW_REQUESTS_JSON='{"headRefOid":"current-head","reviews":[{"author":{"login":"copilot-pull-request-reviewer"},"commit":{"oid":"current-head"},"body":"","submittedAt":"2026-07-20T08:45:35Z"}]}'
+  export GH_THREADS_JSON='{"data":{"repository":{"pullRequest":{"reviewThreads":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"thread-1","isResolved":false,"isOutdated":false,"path":"action.yml","comments":{"nodes":[{"author":{"login":"copilot-pull-request-reviewer"}}]}}]}}}}}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-copilot-review-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "1 unresolved Copilot review thread(s) on PR #42:"
+}
+
+@test "blocks auto-merge while the pull request is draft" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":true,"headRefOid":"current-head","statusCheckRollup":[]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "PR #42 is still a draft; blocking auto-merge."
+}
+
+@test "state gate rejects a pull request head change during evaluation" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"new-head","statusCheckRollup":[]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml \
+    --head expected-head
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "PR #42 head changed from expected-head to new-head; blocking auto-merge."
+}
+
+@test "approval gate refuses to approve a different pull request head" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"new-head"}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/approve-pull-request.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --head expected-head
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "PR #42 head changed from expected-head to new-head; refusing approval."
+  [ ! -e "$GH_API_CAPTURE_FILE" ]
+}
+
+@test "approval gate refuses to approve a draft pull request" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":true,"headRefOid":"expected-head"}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/approve-pull-request.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --head expected-head
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "PR #42 is a draft; refusing approval."
+  [ ! -e "$GH_API_CAPTURE_FILE" ]
+}
+
+@test "approval is attached to the expected pull request head" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"expected-head"}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/approve-pull-request.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --head expected-head
+
+  [ "$status" -eq 0 ]
+  run grep -Fx -- "repos/trade-tariff/example/pulls/42/reviews" "$GH_API_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+  run grep -Fx -- "event=APPROVE" "$GH_API_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+  run grep -Fx -- "commit_id=expected-head" "$GH_API_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "requires a CI run for the current pull request head" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":[]}'
+  export GH_RUNS_JSON='[{"headSha":"previous-head","status":"completed","conclusion":"success","createdAt":"2026-07-20T08:40:00Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "No ci.yml run exists for the current head of PR #42; blocking auto-merge."
+}
+
+@test "blocks auto-merge while current-head CI is pending" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":[]}'
+  export GH_RUNS_JSON='[{"headSha":"current-head","status":"in_progress","conclusion":"","createdAt":"2026-07-20T08:43:10Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "The current-head ci.yml run for PR #42 is in_progress; blocking auto-merge."
+}
+
+@test "blocks auto-merge when current-head CI is unsuccessful" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":[]}'
+  export GH_RUNS_JSON='[{"headSha":"current-head","status":"completed","conclusion":"failure","createdAt":"2026-07-20T08:43:10Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "The current-head ci.yml run for PR #42 concluded failure; blocking auto-merge."
+}
+
+@test "blocks auto-merge while another current-head workflow is pending" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":[{"__typename":"CheckRun","name":"Analyze (ruby)","workflowName":"CodeQL Advanced","status":"IN_PROGRESS","conclusion":""},{"__typename":"CheckRun","name":"auto-merge / auto-merge","workflowName":"Auto-merge low-risk PRs","status":"IN_PROGRESS","conclusion":""}]}'
+  export GH_RUNS_JSON='[{"headSha":"current-head","status":"completed","conclusion":"success","createdAt":"2026-07-20T08:43:10Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 1 ]
+  assert_contains "$output" "1 current-head check has not completed successfully for PR #42:"
+  assert_contains "$output" "CodeQL Advanced / Analyze (ruby): IN_PROGRESS"
+}
+
+@test "passes when the pull request is ready and every current-head check is green" {
+  export GH_REVIEW_REQUESTS_JSON='{"isDraft":false,"headRefOid":"current-head","statusCheckRollup":[{"__typename":"CheckRun","name":"lint","workflowName":"ci","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","name":"deploy","workflowName":"Deploy to development","status":"COMPLETED","conclusion":"SKIPPED"},{"__typename":"CheckRun","name":"CodeQL","workflowName":"","status":"COMPLETED","conclusion":"NEUTRAL"},{"__typename":"CheckRun","name":"auto-merge / auto-merge","workflowName":"Auto-merge low-risk PRs","status":"IN_PROGRESS","conclusion":""}]}'
+  export GH_RUNS_JSON='[{"headSha":"current-head","status":"completed","conclusion":"success","createdAt":"2026-07-20T08:43:10Z"}]'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --workflow ci.yml
+
+  [ "$status" -eq 0 ]
+}
+
+@test "reusable workflow wires the current pull request state gate" {
+  action="$repo_root/.github/actions/auto-merge-low-risk/action.yml"
+  orchestrator="$repo_root/.github/actions/auto-merge-low-risk/auto-merge.sh"
+  workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
+  ci_workflow="$repo_root/.github/workflows/ci.yml"
+
+  run grep -F "required-workflow:" "$action"
+  [ "$status" -eq 0 ]
+  run grep -F 'auto-merge.sh' "$action"
+  [ "$status" -eq 0 ]
+  run grep -F 'check-pull-request-state-gate.sh' "$orchestrator"
+  [ "$status" -eq 0 ]
+  run grep -F 'disable-auto-merge.sh' "$orchestrator"
+  [ "$status" -eq 0 ]
+  run grep -F 'approve-pull-request.sh' "$orchestrator"
+  [ "$status" -eq 0 ]
+  run grep -F 'gh pr review' "$orchestrator"
+  [ "$status" -ne 0 ]
+  run grep -F -- '--head "$expected_head"' "$orchestrator"
+  [ "$status" -eq 0 ]
+  run grep -F -- '--match-head-commit "$expected_head"' "$orchestrator"
+  [ "$status" -eq 0 ]
+  run grep -F 'required-workflow: ${{ inputs.required-workflow }}' "$workflow"
+  [ "$status" -eq 0 ]
+  run grep -F '.github/actions/auto-merge-low-risk/check-pull-request-state-gate.sh' "$ci_workflow"
+  [ "$status" -eq 0 ]
+  run grep -F '.github/actions/auto-merge-low-risk/disable-auto-merge.sh' "$ci_workflow"
+  [ "$status" -eq 0 ]
+  run grep -F '.github/actions/auto-merge-low-risk/approve-pull-request.sh' "$ci_workflow"
+  [ "$status" -eq 0 ]
+}
+
+make_orchestration_harness() {
+  harness="$tmpdir/action"
+  mkdir -p "$harness"
+  cp "$repo_root/.github/actions/auto-merge-low-risk/auto-merge.sh" "$harness/auto-merge.sh"
+  chmod +x "$harness/auto-merge.sh"
+  export ORCHESTRATION_LOG="$tmpdir/orchestration.log"
+
+  for helper in disable-auto-merge check-copilot-review-gate check-pull-request-state-gate request-copilot-review approve-pull-request; do
+    cat > "$harness/$helper.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+name="$(basename "$0" .sh)"
+printf '%s %s\n' "$name" "$*" >> "$ORCHESTRATION_LOG"
+case "$name" in
+  check-copilot-review-gate) exit "${COPILOT_GATE_STATUS:-0}" ;;
+  check-pull-request-state-gate) exit "${STATE_GATE_STATUS:-0}" ;;
+esac
+STUB
+    chmod +x "$harness/$helper.sh"
+  done
+}
+
+run_orchestration() {
+  run "$harness/auto-merge.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --label low-risk \
+    --merge-method squash \
+    --required-workflow ci.yml
+}
+
+@test "orchestration disarms first and never approves or merges without a current-head review" {
+  make_orchestration_harness
+  export GH_REVIEW_REQUESTS_JSON='{"labels":[{"name":"low-risk"}],"headRefOid":"expected-head"}'
+  export COPILOT_GATE_STATUS=2
+
+  run_orchestration
+
+  [ "$status" -eq 0 ]
+  [ "$(sed -n '1p' "$ORCHESTRATION_LOG")" = "disable-auto-merge --repo trade-tariff/example --pr 42 --merge-method squash" ]
+  run grep -E '^(approve-pull-request|merge) ' "$ORCHESTRATION_LOG"
+  [ "$status" -ne 0 ]
+}
+
+@test "orchestration never approves or merges when pull request state or checks fail" {
+  make_orchestration_harness
+  export GH_REVIEW_REQUESTS_JSON='{"labels":[{"name":"low-risk"}],"headRefOid":"expected-head"}'
+  export COPILOT_GATE_STATUS=0
+  export STATE_GATE_STATUS=1
+
+  run_orchestration
+
+  [ "$status" -eq 0 ]
+  run grep -E '^(approve-pull-request|merge) ' "$ORCHESTRATION_LOG"
+  [ "$status" -ne 0 ]
+}
+
+@test "orchestration approves before merging and binds every gate to one head" {
+  make_orchestration_harness
+  export GH_REVIEW_REQUESTS_JSON='{"labels":[{"name":"low-risk"}],"headRefOid":"expected-head"}'
+  export COPILOT_GATE_STATUS=0
+  export STATE_GATE_STATUS=0
+
+  run_orchestration
+
+  [ "$status" -eq 0 ]
+  expected="$tmpdir/expected.log"
+  cat > "$expected" <<'EOF'
+disable-auto-merge --repo trade-tariff/example --pr 42 --merge-method squash
+check-copilot-review-gate --repo trade-tariff/example --pr 42 --head expected-head
+check-pull-request-state-gate --repo trade-tariff/example --pr 42 --workflow ci.yml --head expected-head
+approve-pull-request --repo trade-tariff/example --pr 42 --head expected-head
+merge pr merge 42 --repo trade-tariff/example --squash --match-head-commit expected-head
+EOF
+  run diff -u "$expected" "$ORCHESTRATION_LOG"
+  [ "$status" -eq 0 ]
+}
+
 @test "reusable workflow only handles Copilot review events" {
   workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
 
   run grep -F "github.event_name != 'pull_request_review' ||" "$workflow"
   [ "$status" -eq 0 ]
 
-  run grep -F "contains(github.event.review.user.login, 'copilot')" "$workflow"
+  run grep -F "github.event.review.user.login == 'copilot-pull-request-reviewer'" "$workflow"
   [ "$status" -eq 0 ]
+
+  run grep -F "contains(github.event.review.user.login, 'copilot')" "$workflow"
+  [ "$status" -ne 0 ]
 }

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -87,7 +87,20 @@ teardown() {
   assert_contains "$output" "Requesting Copilot code review for PR #42"
   run grep -Fx -- "--add-reviewer" "$GH_CAPTURE_FILE"
   [ "$status" -eq 0 ]
-  run grep -Fx "copilot" "$GH_CAPTURE_FILE"
+  run grep -Fx "copilot-pull-request-reviewer" "$GH_CAPTURE_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "does not treat an impostor account as an outstanding Copilot request" {
+  export GH_REVIEW_REQUESTS_JSON='{"reviewRequests":[{"__typename":"User","login":"helpful-copilot-reviewer"}]}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/request-copilot-review.sh" \
+    --repo trade-tariff/example \
+    --pr 42
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "Requesting Copilot code review for PR #42"
+  run grep -Fx "copilot-pull-request-reviewer" "$GH_CAPTURE_FILE"
   [ "$status" -eq 0 ]
 }
 

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -418,6 +418,22 @@ run_orchestration() {
     --required-workflow ci.yml
 }
 
+@test "orchestration treats the enabling label as a literal string" {
+  make_orchestration_harness
+  export GH_REVIEW_REQUESTS_JSON='{"labels":[{"name":"lowXrisk"}],"headRefOid":"expected-head"}'
+
+  run "$harness/auto-merge.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --label 'low.risk' \
+    --merge-method squash \
+    --required-workflow ci.yml
+
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "$ORCHESTRATION_LOG")" -eq 1 ]
+  assert_contains "$output" "does not have the low.risk label; skipping."
+}
+
 @test "orchestration disarms first and never approves or merges without a current-head review" {
   make_orchestration_harness
   export GH_REVIEW_REQUESTS_JSON='{"labels":[{"name":"low-risk"}],"headRefOid":"expected-head"}'


### PR DESCRIPTION
### Jira link

No ticket/issue

### What?

I have altered the shared low-risk auto-merge action to:

- disarm any legacy GitHub auto-merge request before evaluating fresh gates
- require an exact-allowlisted Copilot review for the current head and resolved Copilot threads
- fail closed for draft PRs, unavailable review-thread data, missing/pending/failed exact-head CI, and other blocking current-head checks
- bind review, state validation, service approval, and immediate merge to one snapshotted head SHA
- add regression coverage for stale and impostor reviews, orchestration order, SHA pinning, API null shapes, literal label matching, and helper validation

### Why?

The previous action could accept a Copilot review from an older commit after a force-push, then approve or leave auto-merge armed before exact-head CI and review completed. This was observed on trade-tariff-backend PR #3530. The token itself has not changed; the defect is in the gate semantics.

This PR is based on merged PR #171, which separately made Copilot quota exhaustion fail closed.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I have added
- [x] Respected peoples right not to receive lots of noisy messages