### PR TITLE
fix: avoid requiring caller actions permission

### DIFF
--- a/.github/workflows/auto-merge-low-risk.yml
+++ b/.github/workflows/auto-merge-low-risk.yml
@@ -26,7 +26,6 @@ on:
         required: true
 
 permissions:
-  actions: read
   contents: write
   pull-requests: write
 

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -552,9 +552,12 @@ EOF
   [ "$status" -ne 0 ]
 }
 
-@test "reusable workflow can read exact-head workflow runs" {
+@test "reusable workflow does not require callers to grant actions read" {
   workflow="$repo_root/.github/workflows/auto-merge-low-risk.yml"
 
   run grep -F "actions: read" "$workflow"
+  [ "$status" -eq 1 ]
+
+  run grep -F 'github-token: ${{ secrets.github-token }}' "$workflow"
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
### Jira link

No ticket/issue.

### What?

- [x] Removed the reusable workflow's unnecessary `actions: read` request.
- [x] Replaced the workflow contract test that enforced that incompatible permission with one that forbids it and confirms the explicit PAT remains wired.

### Why?

The reusable automerger receives `PULL_REQUEST_PAT` through its `github-token` input for GitHub API access. Its `permissions:` block controls only the caller's `GITHUB_TOKEN`.

Requesting `actions: read` at the reusable-workflow level causes GitHub to reject existing consumers at startup when their caller workflow grants `actions: none`. This was reproduced by trade-tariff-backend run 29759500300.

### Verification

- TDD regression: failed before the workflow change, passed after it
- Bats: 120/120
- Jest: 9/9
- Bash syntax: pass
- ShellCheck error severity: pass
- actionlint: pass
- `git diff --check`: pass
- commit hooks: pass

### Have you? (optional)

- [x] Preserved the existing explicit PAT interface and least-privilege caller contract
- [x] Avoided expanding permissions in every consumer repository