### PR TITLE
fix(actions): skip auto-merge gracefully when Copilot is not enabled

### DIFF
--- a/.github/actions/auto-merge-low-risk/auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/auto-merge.sh
@@ -82,7 +82,14 @@ gate_status=$?
 set -e
 
 if [[ "$gate_status" -eq 2 ]]; then
+  set +e
   "$request_script" --repo "$repo" --pr "$pr"
+  request_status=$?
+  set -e
+  if [[ "$request_status" -ne 0 ]]; then
+    echo "::warning::Unable to request Copilot review for PR #$pr (exit $request_status); Copilot may not be enabled for this repository. Skipping auto-merge."
+    exit 0
+  fi
   echo "Waiting for Copilot to review PR #$pr; auto-merge will be retried on the next workflow run."
   exit 0
 fi


### PR DESCRIPTION
### Jira link

No ticket/issue

### What?

I have added/removed/altered:

- [x] Made `request-copilot-review.sh` failure non-fatal in `auto-merge.sh`

### Why?

When a repository uses the `auto-merge-low-risk` action but does not have
Copilot code review configured, the action was failing with exit code 4 from
`gh` (authentication/permission error when trying to request a Copilot review).
This caused the job to fail and block merges.

The fix runs `request-copilot-review.sh` under `set +e`, captures its exit
code, and treats any non-zero result as a graceful skip with a warning rather
than a job failure. No changes are required in consuming repositories.

### Have you? (optional)

- [x] Respected people's right not to receive lots of noisy messages