### PR TITLE
feat(deploy): automatic rollback when e2e tests fail on staging or production

### DIFF
--- a/.github/actions/rollback/action.yml
+++ b/.github/actions/rollback/action.yml
@@ -1,0 +1,51 @@
+name: 'Rollback ECS deployment'
+description: 'Rolls back an ECS deployment by re-applying Terraform with the previous Docker image tag.'
+
+env:
+  TF_INPUT: 0
+  TF_IN_AUTOMATION: 1
+  TERRAFORM_VERSION: 1.12
+
+inputs:
+  environment:
+    required: true
+    description: 'The environment to roll back.'
+  previous-ref:
+    required: true
+    description: 'The Docker image tag to roll back to.'
+  role-to-assume:
+    description: 'The IAM role ARN to assume for AWS operations.'
+    required: true
+  region:
+    required: false
+    default: 'eu-west-2'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.region }}
+    - uses: hashicorp/setup-terraform@v4
+      with:
+        terraform_version: ${{ env.TERRAFORM_VERSION }}
+    - run: cd terraform && terraform init -backend-config=backends/${{ inputs.environment }}.tfbackend
+      shell: bash
+    - name: Roll back to previous image tag
+      run: |
+        echo "::notice::Rolling back ${{ inputs.environment }} to ${{ inputs.previous-ref }}"
+        cd terraform && terraform apply \
+          -var-file=config_${{ inputs.environment }}.tfvars \
+          -auto-approve \
+          -lock-timeout=10m
+      shell: bash
+      env:
+        TF_VAR_docker_tag: ${{ inputs.previous-ref }}
+    - name: Log rollback to step summary
+      if: always()
+      shell: bash
+      run: |
+        echo "## Rollback" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Environment:** ${{ inputs.environment }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "- **Rolled back to:** \`${{ inputs.previous-ref }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -75,6 +75,7 @@ jobs:
       docker_tag: ${{ steps.config.outputs.docker_tag }}
       ecr_url: ${{ steps.config.outputs.ecr_url }}
       iam_role_arn: ${{ steps.config.outputs.iam_role_arn }}
+      previous_docker_tag: ${{ steps.config.outputs.previous_docker_tag }}
       ruby_version: ${{ steps.config.outputs.ruby_version }}
       slack_channel: ${{ steps.config.outputs.slack_channel }}
     steps:
@@ -110,11 +111,40 @@ jobs:
           app-name: ${{ inputs.app-name }}
           environment: ${{ inputs.environment }}
 
+      - uses: aws-actions/configure-aws-credentials@6.2.2
+        with:
+          role-to-assume: ${{ steps.environment-config.outputs.deploy-role-arn }}
+          aws-region: eu-west-2
+
       - id: config
+        env:
+          APP_NAME: ${{ inputs.app-name }}
+          CLUSTER: ${{ steps.environment-config.outputs.cluster }}
         run: |
+          PREVIOUS_DOCKER_TAG=""
+          # Derive the ECS service name from the app name (e.g. tariff-backend -> tariff-backend-uk)
+          # Services follow the pattern <app-name>-<suffix>; we pick the first matching service.
+          SERVICES=$(aws ecs list-services --cluster "$CLUSTER" --query 'serviceArns' --output text)
+          for SERVICE_ARN in $SERVICES; do
+            SERVICE_NAME=$(basename "$SERVICE_ARN")
+            if [[ "$SERVICE_NAME" == ${APP_NAME}* ]]; then
+              TASK_DEF=$(aws ecs describe-services \
+                --cluster "$CLUSTER" \
+                --services "$SERVICE_NAME" \
+                --query 'services[0].taskDefinition' \
+                --output text)
+              IMAGE=$(aws ecs describe-task-definition \
+                --task-definition "$TASK_DEF" \
+                --query 'taskDefinition.containerDefinitions[0].image' \
+                --output text)
+              PREVIOUS_DOCKER_TAG="${IMAGE##*:}"
+              break
+            fi
+          done
           {
             echo "ecr_url=${{ steps.environment-config.outputs.ecr-url }}"
             echo "iam_role_arn=${{ steps.environment-config.outputs.deploy-role-arn }}"
+            echo "previous_docker_tag=${PREVIOUS_DOCKER_TAG}"
             echo "ruby_version=$(cat .ruby-version)"
             echo "slack_channel=${{ steps.environment-config.outputs.slack-channel }}"
             echo "docker_tag=$(git rev-parse --short HEAD)"
@@ -209,6 +239,34 @@ jobs:
       non_admin_bypass_password: ${{ secrets.non_admin_bypass_password }}
       admin_bypass_password: ${{ secrets.admin_bypass_password }}
 
+  rollback:
+    name: Rollback on e2e failure
+    if: |
+      always() &&
+      needs.deploy.result == 'success' &&
+      (needs.e2e-test-tariff.result == 'failure' || needs.e2e-test-fpo.result == 'failure') &&
+      needs.configure.outputs.previous_docker_tag != '' &&
+      (inputs.environment == 'staging' || inputs.environment == 'production')
+    runs-on: ubuntu-latest
+    needs:
+      - configure
+      - deploy
+      - e2e-test-tariff
+      - e2e-test-fpo
+    steps:
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
+        with:
+          ssh-key: ${{ secrets.ssh-key }}
+      - uses: actions/checkout@v7.0.0
+        with:
+          repository: ${{ needs.configure.outputs.actual_repo }}
+          ref: ${{ needs.configure.outputs.actual_ref }}
+      - uses: trade-tariff/trade-tariff-tools/.github/actions/rollback@main
+        with:
+          environment: ${{ inputs.environment }}
+          previous-ref: ${{ needs.configure.outputs.previous_docker_tag }}
+          role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
+
   notify:
     if: ${{ always() && inputs.notify }}
     runs-on: ubuntu-latest
@@ -217,6 +275,7 @@ jobs:
       - deploy
       - e2e-test-tariff
       - e2e-test-fpo
+      - rollback
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/setup-ssh@main
         with:
@@ -244,11 +303,22 @@ jobs:
           TEST_FLAVOUR="${{ inputs.test-flavour }}"
 
           if [[ "$TEST_FLAVOUR" == "tariff" ]]; then
-            echo "result=${{ needs.e2e-test-tariff.result }}" >> "$GITHUB_OUTPUT"
+            E2E_RESULT="${{ needs.e2e-test-tariff.result }}"
           elif [[ "$TEST_FLAVOUR" == "fpo" ]]; then
-            echo "result=${{ needs.e2e-test-fpo.result }}" >> "$GITHUB_OUTPUT"
+            E2E_RESULT="${{ needs.e2e-test-fpo.result }}"
           else
-            echo "result=${{ needs.deploy.result }}" >> "$GITHUB_OUTPUT"
+            E2E_RESULT="${{ needs.deploy.result }}"
+          fi
+
+          ROLLBACK_RESULT="${{ needs.rollback.result }}"
+          echo "result=${E2E_RESULT}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$ROLLBACK_RESULT" == "success" ]]; then
+            echo "rollback_message=Rolled back to \`${{ needs.configure.outputs.previous_docker_tag }}\`" >> "$GITHUB_OUTPUT"
+          elif [[ "$ROLLBACK_RESULT" == "failure" ]]; then
+            echo "rollback_message=Rollback to \`${{ needs.configure.outputs.previous_docker_tag }}\` FAILED — manual intervention required" >> "$GITHUB_OUTPUT"
+          else
+            echo "rollback_message=" >> "$GITHUB_OUTPUT"
           fi
 
       - id: pr-info
@@ -264,11 +334,21 @@ jobs:
           RESULT: ${{ steps.result.outputs.result }}
         run: .trade-tariff-tools/scripts/deploy-pr-info.sh
 
+      - id: notify-message
+        run: |
+          BASE="${{ steps.pr-info.outputs.message || format('Deploy to {0} {1}', inputs.environment, steps.result.outputs.result) }}"
+          ROLLBACK="${{ steps.result.outputs.rollback_message }}"
+          if [[ -n "$ROLLBACK" ]]; then
+            echo "message=${BASE} — ${ROLLBACK}" >> "$GITHUB_OUTPUT"
+          else
+            echo "message=${BASE}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:
           webhook: ${{ secrets.slack-webhook }}
           channel: ${{ needs.configure.outputs.slack_channel }}
           color: ${{ steps.result.outputs.result }}
           title: "${{ github.workflow }}"
-          message: "${{ steps.pr-info.outputs.message || format('Deploy to {0} {1}', inputs.environment, steps.result.outputs.result) }}"
+          message: "${{ steps.notify-message.outputs.message }}"
       - run: if [[ "${{ steps.result.outputs.result }}" != "success" ]]; then exit 1; fi


### PR DESCRIPTION
### Jira link

[HMRC-2528](https://transformuk.atlassian.net/browse/HMRC-2528)

### What?

- [x] Added a new `rollback` composite action (`.github/actions/rollback/action.yml`) that re-applies Terraform with a previous Docker image tag
- [x] Extended `deploy-ecs.yml` configure job to capture the currently-running ECS image tag before deploying (the rollback target)
- [x] Added a `rollback` job to `deploy-ecs.yml` that fires automatically when e2e tests fail on staging or production
- [x] Updated the `notify` job to report rollback outcome in the Slack message

### Why?

When an e2e test suite failure is detected after a deploy to staging or production, there was no automated mechanism to restore the previous version. A broken build would remain live until someone manually intervened.

This change adds an automatic rollback triggered by e2e failure. The previous image tag is captured by querying ECS at the start of the configure job — so the rollback target is always whatever was actually running at deploy time, not a convention or ECR label.

Rollback is skipped for the development environment, when the deploy itself failed (nothing to roll back from), and when no previous tag could be determined.

### Notes for reviewers

- The `configure` job now assumes AWS credentials to call `ecs:ListServices`, `ecs:DescribeServices`, and `ecs:DescribeTaskDefinition`. The existing `GithubActions-ECS-Deployments-Role` should already have `DescribeServices`/`DescribeTaskDefinition` — worth confirming `ListServices` is included.
- Rollback does not reverse database migrations (same as any manual rollback would). Migrations must remain backwards-compatible per Rails convention.
- If rollback itself fails, the Slack notification calls this out explicitly so the team knows manual intervention is needed.

### Have you?

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages