### PR TITLE
Preserve multiline deployment notifications

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -335,14 +335,20 @@ jobs:
         run: .trade-tariff-tools/scripts/deploy-pr-info.sh
 
       - id: notify-message
+        env:
+          BASE: ${{ steps.pr-info.outputs.message || format('Deploy to {0} {1}', inputs.environment, steps.result.outputs.result) }}
+          ROLLBACK: ${{ steps.result.outputs.rollback_message }}
         run: |
-          BASE="${{ steps.pr-info.outputs.message || format('Deploy to {0} {1}', inputs.environment, steps.result.outputs.result) }}"
-          ROLLBACK="${{ steps.result.outputs.rollback_message }}"
+          message="$BASE"
           if [[ -n "$ROLLBACK" ]]; then
-            echo "message=${BASE} — ${ROLLBACK}" >> "$GITHUB_OUTPUT"
-          else
-            echo "message=${BASE}" >> "$GITHUB_OUTPUT"
+            message="${message} — ${ROLLBACK}"
           fi
+
+          {
+            echo 'message<<NOTIFY_EOF'
+            printf '%s\n' "$message"
+            echo 'NOTIFY_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - uses: trade-tariff/trade-tariff-tools/.github/actions/slack-notify@main
         with:

--- a/tests/notify-pr-info.bats
+++ b/tests/notify-pr-info.bats
@@ -276,3 +276,22 @@ STUB
   run grep -F "steps.pr-info.outputs.message ||" "$workflow"
   [ "$status" -eq 0 ]
 }
+
+@test "deploy-ecs preserves multiline notification messages in step output" {
+  workflow="$repo_root/.github/workflows/deploy-ecs.yml"
+
+  run grep -F "BASE: \${{ steps.pr-info.outputs.message ||" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "ROLLBACK: \${{ steps.result.outputs.rollback_message }}" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "echo 'message<<NOTIFY_EOF'" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "printf '%s\\n' \"\$message\"" "$workflow"
+  [ "$status" -eq 0 ]
+
+  run grep -F "echo 'NOTIFY_EOF'" "$workflow"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Jira link

N/A

### What?

I have added/removed/altered:

- [x] Write deployment notification messages to `$GITHUB_OUTPUT` using multiline delimiter syntax
- [x] Pass PR-derived notification text through environment variables rather than interpolating it into shell source
- [x] Add a regression test for the reusable deployment workflow contract

### Why?

I am doing this because:

- Multiline PR deployment messages currently make the notification job fail with `Invalid format`, even after a successful deployment
- Failed notification checks prevent the low-risk auto-merger from merging otherwise-green pull requests
- Verification: all 121 Bats tests, shell syntax checks, `actionlint`, ShellCheck, YAML validation, TruffleHog, and repository pre-commit hooks pass

### Have you? (optional)

- [x] Respected people's right not to receive lots of noisy messages