### PR TITLE
Clarify inactive auto-merge log message

### DIFF
--- a/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
+++ b/.github/actions/auto-merge-low-risk/disable-auto-merge.sh
@@ -64,5 +64,5 @@ if [[ "$auto_merge_enabled" == "true" ]]; then
     "--${merge_method}" \
     --disable-auto
 else
-  echo "Auto-merge is not enabled for PR #$pr; nothing to disable."
+  echo "No GitHub auto-merge request is running for PR #$pr; nothing to disable."
 fi

--- a/tests/auto-merge-low-risk.bats
+++ b/tests/auto-merge-low-risk.bats
@@ -199,6 +199,18 @@ teardown() {
   assert_contains "$output" "PR #42 has not been reviewed by Copilot at its current head."
 }
 
+@test "describes an absent auto-merge request as not running" {
+  export GH_REVIEW_REQUESTS_JSON='{"autoMergeRequest":null}'
+
+  run "$repo_root/.github/actions/auto-merge-low-risk/disable-auto-merge.sh" \
+    --repo trade-tariff/example \
+    --pr 42 \
+    --merge-method rebase
+
+  [ "$status" -eq 0 ]
+  assert_contains "$output" "No GitHub auto-merge request is running for PR #42; nothing to disable."
+}
+
 @test "disable helper documents its accepted merge methods" {
   run "$repo_root/.github/actions/auto-merge-low-risk/disable-auto-merge.sh" --help
 


### PR DESCRIPTION
### Jira link

BAU

### What?

I have altered:

- [x] Describe an absent GitHub auto-merge request as not running
- [x] Cover the inactive path with a Bats regression test

### Why?

I am doing this because:

- “Auto-merge is not enabled” reads as though the auto-merge workflow is disabled while that workflow is visibly running.
- Naming the GitHub auto-merge request makes the cleanup step clear without changing its behaviour.

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages
- [x] Passed Bash syntax checks
- [x] Passed 122 Bats tests
- [x] Passed 9 Jest tests