### PR TITLE
Install only Chromium headless shell for E2E tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -72,7 +72,7 @@ jobs:
 
       - run: yarn install
 
-      - run: yarn playwright install --with-deps chromium
+      - run: yarn playwright install --with-deps --only-shell chromium
 
       - run: |
           {

--- a/tests/e2e-tests-workflow.bats
+++ b/tests/e2e-tests-workflow.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "e2e workflow installs only Chromium headless shell" {
+  workflow="$repo_root/.github/workflows/e2e-tests.yml"
+
+  run grep -F \
+    "yarn playwright install --with-deps --only-shell chromium" \
+    "$workflow"
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
### Jira link

No ticket/issue

### What?

I have added/removed/altered:

- [x] Altered the reusable E2E workflow to install only the Chromium headless shell
- [x] Added a Bats regression contract for the Playwright install command

### Why?

I am doing this because:

- The workflow runs Playwright headlessly and does not use the full Chromium binary
- Avoiding the unused browser download reduces setup time and runner bandwidth
- Browser execution remains unchanged

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I have added
- [x] Respected peoples right not to receive lots of noisy messages
