### PR TITLE
BAU: bump deploy Alpine to 3.24 for Ruby 4.0.6

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -168,7 +168,7 @@ jobs:
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}
       - uses: trade-tariff/trade-tariff-tools/.github/actions/build-and-push@main
         with:
-          build-args: "RUBY_VERSION=${{ needs.configure.outputs.ruby_version }} ALPINE_VERSION=3.22 ${{ inputs.build-args }}"
+          build-args: "RUBY_VERSION=${{ needs.configure.outputs.ruby_version }} ALPINE_VERSION=3.24 ${{ inputs.build-args }}"
           ecr-url: ${{ needs.configure.outputs.ecr_url }}
           ref: ${{ needs.configure.outputs.docker_tag }}
           role-to-assume: ${{ needs.configure.outputs.iam_role_arn }}


### PR DESCRIPTION
## What:
Bump the hardcoded ECS deploy build-arg from Alpine **3.22** to **3.24**.

```yaml
# .github/workflows/deploy-ecs.yml
build-args: "... ALPINE_VERSION=3.24 ..."
```

## Why:
Official Docker Hub images for Ruby **4.0.6** include:

- `ruby:4.0.6-alpine3.23`
- `ruby:4.0.6-alpine3.24`
- `ruby:4.0.6-alpine`

There is **no** `ruby:4.0.6-alpine3.22`. Deploy builds for the Ruby 4.0.6 upgrade PRs fail with:

```text
ruby:4.0.6-alpine3.22: not found
```

App Dockerfiles already default to a newer Alpine; this tools override was forcing 3.22.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** Changes only the Alpine patch/minor used as the Ruby base image in ECS builds. No application code or infrastructure resource changes. Aligns with official Ruby Docker tags.