### PR TITLE
BAU: add flagsmith, flagsmith-edge, mcp to service start/stop lists

### DIFF
--- a/.github/workflows/start-development-services.yml
+++ b/.github/workflows/start-development-services.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/start-services@main
         with:
-          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub
+          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub flagsmith flagsmith-edge mcp
           environment: development

--- a/.github/workflows/start-staging-services.yml
+++ b/.github/workflows/start-staging-services.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/start-services@main
         with:
-          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub
+          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub flagsmith flagsmith-edge mcp
           environment: staging

--- a/.github/workflows/stop-development-services.yml
+++ b/.github/workflows/stop-development-services.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/stop-services@main
         with:
-          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub
+          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub flagsmith flagsmith-edge mcp
           environment: development

--- a/.github/workflows/stop-staging-services.yml
+++ b/.github/workflows/stop-staging-services.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: trade-tariff/trade-tariff-tools/.github/actions/stop-services@main
         with:
-          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub
+          service-names: backend-uk backend-xi worker-uk worker-xi admin frontend identity dev-hub flagsmith flagsmith-edge mcp
           environment: staging


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added `flagsmith`, `flagsmith-edge`, and `mcp` to the `service-names` list in start/stop workflows for development and staging environments

### Why?

I am doing this because:

- The flagsmith, flagsmith-edge, and mcp services were missing from the start/stop service lists
- Without this, these services are not started/stopped alongside the rest of the stack in development and staging

### Have you? (optional)

- [x] Clearly documented/self-documented any scripts I've added
- [x] Respected people's right not to receive lots of noisy messages

### Test plan

- [ ] Verified `start-development-services.yml` includes `flagsmith flagsmith-edge mcp`
- [ ] Verified `start-staging-services.yml` includes `flagsmith flagsmith-edge mcp`
- [ ] Verified `stop-development-services.yml` includes `flagsmith flagsmith-edge mcp`
- [ ] Verified `stop-staging-services.yml` includes `flagsmith flagsmith-edge mcp`